### PR TITLE
Fix one-line for..end and if..end block over-indentation issue #61

### DIFF
--- a/Indentation.tmPreferences
+++ b/Indentation.tmPreferences
@@ -12,7 +12,7 @@
     <string>^\s*(end|else|elseif|catch|finally).*$</string>
 
     <key>increaseIndentPattern</key>
-    <string>^\s*(if|else|elseif|for|while|begin|function|type|macro|immutable|try|catch|finally|let|quote|do).*$</string>
+    <string>^\s*(if|else|elseif|for|while|begin|function|type|macro|immutable|try|catch|finally|let|quote|do)(?!.*\bend\b).*$</string>
 
   </dict>
 


### PR DESCRIPTION
If `end` appears on the same line after `if` or `for`, the following line is not indented.