### PR TITLE
Make multi-character operators display correctly as ligatures

### DIFF
--- a/Julia.sublime-syntax
+++ b/Julia.sublime-syntax
@@ -1,628 +1,1191 @@
-%YAML 1.2
----
+# SYNTAX TEST "Packages/Julia/Julia.sublime-syntax"
 
-# https://www.sublimetext.com/docs/3/syntax.html
-# https://www.sublimetext.com/docs/3/scope_naming.html
-
-
-# Julia is a language under development, this syntax strives to
-# support the latest version of Julia.
-# Julia is currently transitioning from version 0.5 to 0.6,
-# the changes in 0.6 are listed here https://github.com/JuliaLang/julia/blob/master/NEWS.md
-# Some syntax is being removed, but kept for now as deprecated, such
-# features are marked with "# DEPRECATED 0.6" in this file.
-
-# TODO: When 0.6 is properly released, re-run all generated regexes, ones commented with "# julia> ...".
-# The current 0.6 alpha had some issues...
+# For information on how this file is used, see
+# https://www.sublimetext.com/docs/3/syntax.html#testing
+# Run tests by pressing `ctrl+shift+b`, i.e. run the `build` command
 
 
-name: Julia
-file_extensions: [jl]
-first_line_match: ^#!.*\bjulia\s*$
-scope: source.julia
+##
+## NUMBERS
+##
 
-variables:
-  symb_op_ascii: '[-+*/\\=^:<>~?&$%|]'
+  0b101
+# ^^^^^ constant.numeric
+  0o7
+# ^^^ constant.numeric
+  0xa3
+# ^^^^ constant.numeric
+  1e+123
+# ^^^^^^ constant.numeric
+  12e123
+# ^^^^^^ constant.numeric
+  1.32e+123
+# ^^^^^^^^^ constant.numeric
+  .32e+123
+# ^^^^^^^^ constant.numeric
+  1.e-123
+# ^^^^^^^ constant.numeric
+  11
+# ^^ constant.numeric
+  .11
+# ^^^ constant.numeric
+  11.
+# ^^^ constant.numeric
+  11.11
+# ^^^^^ constant.numeric
+  2.a
+# ^^ constant.numeric
+#   ^ variable.other
+# (issue 37)
+  123_4_56_7
+# ^^^^^^^^^^ constant.numeric
+  0xa_3_f
+# ^^^^^^^ constant.numeric
+  0b1_0_1
+# ^^^^^^^ constant.numeric
+  1.3_2e+1_2_3
+# ^^^^^^^^^^^^ constant.numeric
+# (issue 51)
+  e2
+# ^^ variable.other
+  2e
+# ^ constant.numeric
+#  ^ support.function
+  2e2
+# ^^^ constant.numeric
+  e+2
+# ^ support.function
+#  ^ keyword.operator
+#   ^ constant.numeric
+  2+e
+# ^ constant.numeric
+#  ^ keyword.operator
+#   ^ support.function
 
-  # The list of unicode symbols allowed as operators is fetched from the Julia parser https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm
-  symb_op_unicode: '[≤≥¬←→↔↚↛↠↣↦↮⇎⇏⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⭄⭇⭈⭉⭊⭋⭌￩￫≡≠≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≔≕≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩴⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⊕⊖⊞⊟∪∨⊔±∓∔∸≂≏⊎⊻⊽⋎⋓⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣÷⋅∘×∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬]'
-  symb_op: '(?:{{symb_op_ascii}}|{{symb_op_unicode}})'
 
-  # Multi-character operators
-  long_op: (?:\+=|-=|\*=|/=|//=|\\\\=|^=|÷=|%=|<<=|>>=|>>>=|\|=|&=|:=|=>|$=|\|\||<:|>:|\|>|<\||//|\+\+)
+##
+## CONSTANTS
+##
 
-  # julia> join(sort(unique((filter(x -> isalpha(x[1]), string.(filter!(x -> isa(eval(x), DataType) || isa(eval(x), TypeConstructor), [names(Base); names(Core)])))))), "|")
-  # Julia 0.6 seems to uses UnionAll instead of TypeConstructor
-  # Compare with https://github.com/JuliaLang/julia/blob/master/base/exports.jl
-  base_types: \b(?:AbstractArray|AbstractChannel|AbstractFloat|AbstractMatrix|AbstractRNG|AbstractSerializer|AbstractSparseArray|AbstractSparseMatrix|AbstractSparseVector|AbstractString|AbstractUnitRange|AbstractVecOrMat|AbstractVector|Any|ArgumentError|Array|AssertionError|Associative|Base64DecodePipe|Base64EncodePipe|Bidiagonal|BigFloat|BigInt|BitArray|BitMatrix|BitVector|Bool|BoundsError|BufferStream|CachingPool|CapturedException|CartesianIndex|CartesianRange|Cchar|Cdouble|Cfloat|Channel|Char|Cint|Cintmax_t|Clong|Clonglong|ClusterManager|Cmd|Colon|Complex|Complex128|Complex32|Complex64|CompositeException|Condition|Cptrdiff_t|Cshort|Csize_t|Cssize_t|Cstring|Cuchar|Cuint|Cuintmax_t|Culong|Culonglong|Cushort|Cwchar_t|Cwstring|DataType|Date|DateTime|DenseArray|DenseMatrix|DenseVecOrMat|DenseVector|Diagonal|Dict|DimensionMismatch|Dims|DirectIndexString|Display|DivideError|DomainError|EOFError|EachLine|Enum|Enumerate|ErrorException|Exception|Expr|Factorization|FileMonitor|Filter|Float16|Float32|Float64|FloatRange|Function|Future|GlobalRef|GotoNode|HTML|Hermitian|IO|IOBuffer|IOContext|IOStream|IPAddr|IPv4|IPv6|InexactError|InitError|Int|Int128|Int16|Int32|Int64|Int8|IntSet|Integer|InterruptException|InvalidStateException|Irrational|KeyError|LabelNode|LambdaInfo|LinSpace|LineNumberNode|LoadError|LowerTriangular|MIME|Matrix|MersenneTwister|Method|MethodError|MethodTable|Module|NTuple|NewvarNode|NullException|Nullable|Number|ObjectIdDict|OrdinalRange|OutOfMemoryError|OverflowError|Pair|ParseError|PartialQuickSort|Pipe|PollingFileWatcher|ProcessExitedException|Ptr|QuoteNode|RandomDevice|Range|Rational|RawFD|ReadOnlyMemoryError|Real|ReentrantLock|Ref|Regex|RegexMatch|RemoteChannel|RemoteException|RepString|RevString|RoundingMode|SSAValue|SegmentationFault|SerializationState|Set|SharedArray|SharedMatrix|SharedVector|Signed|SimpleVector|Slot|SlotNumber|SparseMatrixCSC|SparseVector|StackFrame|StackOverflowError|StackTrace|StepRange|StridedArray|StridedMatrix|StridedVecOrMat|StridedVector|String|SubArray|SubString|SymTridiagonal|Symbol|Symmetric|SystemError|TCPSocket|Task|Text|TextDisplay|Timer|Tridiagonal|Tuple|Type|TypeConstructor|TypeError|TypeMapEntry|TypeMapLevel|TypeName|TypeVar|TypedSlot|UDPSocket|UInt|UInt128|UInt16|UInt32|UInt64|UInt8|UndefRefError|UndefVarError|UnicodeError|UniformScaling|Union|UnitRange|Unsigned|UpperTriangular|Val|Vararg|VecElement|VecOrMat|Vector|VersionNumber|Void|WeakKeyDict|WeakRef|WorkerConfig|WorkerPool|Zip)\b
+  true
+# ^^^^ constant.language
+  false
+# ^^^^^ constant.language
+  nothing
+# ^^^^^^^ constant.language
+  NaN
+# ^^^ constant.language
+  Inf
+# ^^^ constant.language
 
-  # julia> join(filter!(x -> isascii(x[1]) && isalpha(x[1]) && islower(x[1]), map(string, [names(Base); names(Core)])), '|')
-  base_funcs: (?:abs|abs2|abspath|accept|acos|acosd|acosh|acot|acotd|acoth|acsc|acscd|acsch|addprocs|airy|airyai|airyaiprime|airybi|airybiprime|airyprime|airyx|all|all!|allunique|angle|any|any!|append!|apropos|ascii|asec|asecd|asech|asin|asind|asinh|assert|asyncmap|atan|atan2|atand|atanh|atexit|atreplinit|backtrace|base|base64decode|base64encode|basename|besselh|besselhx|besseli|besselix|besselj|besselj0|besselj1|besseljx|besselk|besselkx|bessely|bessely0|bessely1|besselyx|beta|bfft|bfft!|big|bin|bind|binomial|bitbroadcast|bitpack|bitrand|bits|bitunpack|bkfact|bkfact!|blas_set_num_threads|blkdiag|brfft|broadcast|broadcast!|broadcast!_function|broadcast_function|broadcast_getindex|broadcast_setindex!|bswap|bytes2hex|bytestring|call|cat|catalan|catch_backtrace|catch_stacktrace|cbrt|cd|ceil|cell|cfunction|cglobal|charwidth|checkbounds|checkindex|chmod|chol|cholfact|cholfact!|chomp|chop|chown|chr2ind|circshift|cis|clamp|clamp!|cld|clear!|clipboard|close|cmp|code_llvm|code_lowered|code_native|code_typed|code_warntype|collect|colon|combinations|complex|cond|condskeel|conj|conj!|connect|consume|contains|conv|conv2|convert|copy|copy!|copysign|cor|cos|cosc|cosd|cosh|cospi|cot|cotd|coth|count|count_ones|count_zeros|countfrom|countlines|countnz|cov|cp|cross|csc|cscd|csch|ctime|ctranspose|ctranspose!|cummax|cummin|cumprod|cumprod!|cumsum|cumsum!|cumsum_kbn|current_module|current_task|cycle|dawson|dct|dct!|dec|deconv|deepcopy|default_worker_pool|deg2rad|delete!|deleteat!|den|deserialize|det|detach|diag|diagind|diagm|diff|digamma|digits|digits!|dirname|disable_sigint|display|displayable|displaysize|div|divrem|done|dot|download|drop|dropzeros|dropzeros!|dump|e|eachindex|eachline|eachmatch|edit|eig|eigfact|eigfact!|eigmax|eigmin|eigs|eigvals|eigvals!|eigvecs|eltype|empty!|endof|endswith|enumerate|eof|eps|erf|erfc|erfcinv|erfcx|erfi|erfinv|error|esc|escape_string|eta|etree|eu|eulergamma|evalfile|exit|exp|exp10|exp2|expand|expanduser|expm|expm1|exponent|extrema|eye|factor|factorial|factorize|falses|fd|fdio|fetch|fft|fft!|fftshift|field_offset|fieldname|fieldnames|fieldoffset|fieldoffsets|filemode|filesize|fill|fill!|filt|filt!|filter|filter!|finalize|finalizer|find|findfirst|findin|findlast|findmax|findmax!|findmin|findmin!|findn|findnext|findnz|findprev|first|fld|fld1|fldmod|fldmod1|flipbits!|flipdim|flipsign|float|floor|flush|fma|foldl|foldr|foreach|frexp|full|fullname|functionloc|gamma|gc|gc_enable|gcd|gcdx|gensym|get|get!|get_bigfloat_precision|get_rounding|get_zero_subnormals|getaddrinfo|gethostname|getindex|getipaddr|getkey|getpid|getsockname|givens|golden|gperm|gradient|graphemes|hankelh1|hankelh1x|hankelh2|hankelh2x|hash|haskey|hcat|hessfact|hessfact!|hex|hex2bytes|hex2num|hist|hist!|hist2d|hist2d!|histrange|homedir|htol|hton|hvcat|hypot|idct|idct!|identity|ifelse|ifft|ifft!|ifftshift|ignorestatus|im|imag|in|include|include_dependency|include_string|ind2chr|ind2sub|indexin|indexpids|indices|indmax|indmin|info|init_worker|insert!|instances|interrupt|intersect|intersect!|inv|invdigamma|invmod|invperm|ipermute!|ipermutedims|irfft|is_apple|is_assigned_char|is_bsd|is_linux|is_unix|is_windows|isabspath|isalnum|isalpha|isapprox|isascii|isassigned|isbits|isblockdev|ischardev|iscntrl|isconst|isdiag|isdigit|isdir|isdirpath|isempty|isequal|iseven|isexecutable|isfifo|isfile|isfinite|isgeneric|isgraph|ishermitian|isimag|isimmutable|isinf|isinteger|isinteractive|isleaftype|isless|islink|islocked|islower|ismarked|ismatch|ismount|isnan|isnull|isnumber|isodd|isopen|ispath|isperm|isposdef|isposdef!|ispow2|isprime|isprint|ispunct|isqrt|isreadable|isreadonly|isready|isreal|issetgid|issetuid|issocket|issorted|isspace|issparse|issticky|issubnormal|issubset|issym|issymmetric|istaskdone|istaskstarted|istext|istextmime|istril|istriu|isupper|isvalid|iswritable|isxdigit|join|joinpath|keys|keytype|kill|kron|last|launch|lbeta|lcfirst|lcm|ldexp|ldltfact|ldltfact!|leading_ones|leading_zeros|length|less|levicivita|lexcmp|lexless|lfact|lgamma|linearindices|linreg|linspace|listen|listenany|localindexes|lock|log|log10|log1p|log2|logabsdet|logdet|logm|logspace|lowercase|lpad|lq|lqfact|lqfact!|lstat|lstrip|ltoh|lu|lufact|lufact!|lyap|macroexpand|manage|map|map!|mapfoldl|mapfoldr|mapreduce|mapreducedim|mapslices|mark|match|matchall|max|maxabs|maxabs!|maximum|maximum!|maxintfloat|mean|mean!|median|median!|merge|merge!|method_exists|methods|methodswith|middle|midpoints|mimewritable|min|minabs|minabs!|minimum|minimum!|minmax|mkdir|mkpath|mktemp|mktempdir|mod|mod1|mod2pi|modf|module_name|module_parent|mtime|muladd|mv|myid|names|nb_available|ndigits|ndims|next|nextfloat|nextind|nextpow|nextpow2|nextprod|nnz|nonzeros|norm|normalize|normalize!|normalize_string|normpath|notify|now|nprocs|nthperm|nthperm!|ntoh|ntuple|nullspace|num|num2hex|nworkers|nzrange|object_id|oct|oftype|one|ones|open|operm|ordschur|ordschur!|parent|parentindexes|parity|parse|parseip|partitions|peakflops|permutations|permute|permute!|permutedims|permutedims!|pi|pinv|pipeline|plan_bfft|plan_bfft!|plan_brfft|plan_dct|plan_dct!|plan_fft|plan_fft!|plan_idct|plan_idct!|plan_ifft|plan_ifft!|plan_irfft|plan_rfft|pmap|pointer|pointer_from_objref|pointer_to_array|pointer_to_string|poll_fd|poll_file|polygamma|pop!|popdisplay|position|powermod|precision|precompile|prepend!|prevfloat|prevind|prevpow|prevpow2|prevprod|primes|primesmask|print|print_escaped|print_joined|print_shortest|print_unescaped|print_with_color|println|process_exited|process_running|procs|prod|prod!|produce|promote|promote_rule|promote_shape|promote_type|push!|pushdisplay|put!|pwd|qr|qrfact|qrfact!|quadgk|quantile|quantile!|quit|rad2deg|rand|rand!|randcycle|randexp|randexp!|randjump|randn|randn!|randperm|randstring|randsubseq|randsubseq!|range|rank|rationalize|read|read!|readall|readandwrite|readavailable|readbytes|readbytes!|readchomp|readcsv|readdir|readdlm|readline|readlines|readlink|readstring|readuntil|real|realmax|realmin|realpath|recv|recvfrom|redirect_stderr|redirect_stdin|redirect_stdout|redisplay|reduce|reducedim|reenable_sigint|reim|reinterpret|reload|relpath|rem|rem1|remote|remotecall|remotecall_fetch|remotecall_wait|repeat|repeated|replace|repmat|repr|reprmime|reset|reshape|resize!|rest|rethrow|retry|reverse|reverse!|reverseind|rfft|rm|rmprocs|rol|rol!|ror|ror!|rot180|rotl90|rotr90|round|rounding|rowvals|rpad|rsearch|rsearchindex|rsplit|rstrip|run|scale|scale!|schedule|schur|schurfact|schurfact!|sdata|search|searchindex|searchsorted|searchsortedfirst|searchsortedlast|sec|secd|sech|seek|seekend|seekstart|select|select!|selectperm|selectperm!|send|serialize|set_bigfloat_precision|set_rounding|set_zero_subnormals|setdiff|setdiff!|setenv|setindex!|setprecision|setrounding|shift!|show|showall|showcompact|showcompact_lim|showerror|shuffle|shuffle!|sign|signbit|signed|signif|significand|similar|sin|sinc|sind|sinh|sinpi|size|sizehint!|sizeof|skip|skipchars|sleep|slice|slicedim|sort|sort!|sortcols|sortperm|sortperm!|sortrows|sparse|sparsevec|spawn|spdiagm|specialized_binary|specialized_bitwise_binary|specialized_bitwise_unary|specialized_unary|speye|splice!|split|splitdir|splitdrive|splitext|spones|sprand|sprandbool|sprandn|sprint|spzeros|sqrt|sqrtm|squeeze|srand|stacktrace|start|startswith|stat|std|stdm|step|stride|strides|string|stringmime|strip|strwidth|sub|sub2ind|subtypes|success|sum|sum!|sum_kbn|sumabs|sumabs!|sumabs2|sumabs2!|summary|super|supertype|svd|svdfact|svdfact!|svds|svdvals|svdvals!|sylvester|symbol|symdiff|symdiff!|symlink|symperm|systemerror|take|take!|takebuf_array|takebuf_string|tan|tand|tanh|task_local_storage|tempdir|tempname|tic|time|time_ns|timedwait|toc|toq|touch|trace|trailing_ones|trailing_zeros|trailingsize|transcode|transpose|transpose!|trigamma|tril|tril!|triu|triu!|trues|trunc|truncate|trylock|tryparse|typeintersect|typejoin|typemax|typemin|ucfirst|unescape_string|union|union!|unique|unlock|unmark|unsafe_copy!|unsafe_load|unsafe_pointer_to_objref|unsafe_read|unsafe_store!|unsafe_string|unsafe_trunc|unsafe_wrap|unsafe_write|unshift!|unsigned|uperm|uppercase|utf8|valtype|values|var|varm|vcat|vec|vecdot|vecnorm|versioninfo|view|wait|walkdir|warn|watch_file|which|whos|widemul|widen|with_bigfloat_precision|with_rounding|withenv|workers|workspace|write|writecsv|writedlm|xcorr|xdump|yield|yieldto|zero|zeros|zeta|zip|applicable|eval|fieldtype|getfield|invoke|is|isa|isdefined|issubtype|nfields|nothing|setfield!|throw|tuple|typeassert|typeof)(?!{{symb_id}})
 
-  # julia> join(string.(filter!(x -> isa(eval(x), Module), [names(Base); names(Core)])), "|")
-  base_modules: \b(?:BLAS|Base|Collections|Dates|Docs|FFTW|LAPACK|LibGit2|Libc|Libdl|LinAlg|Markdown|Meta|Mmap|Operators|Pkg|Profile|Serializer|SparseArrays|StackTraces|Sys|Test|Threads|Core|Main)\b
+##
+## FUNCTION CALLS
+##
 
-  # Highlight exported functions from base modules
-  # julia> base_modules = filter!(x -> isa(eval(x), Module) && x != :Main , [names(Base); names(Core)])
-  # julia> modulefunctions(m) = join(filter!(x -> isascii(x[1]) && isalpha(x[1]) && islower(x[1]), string.(names(eval(m)))), "|")
-  # julia> regexify(m) = "$(string(m))\\.(?:$(modulefunctions(m)))"
-  # julia> rows = join(regexify.(base_modules), "|")
-  # julia> print("(<!\\.)(?:$rows)(?!{{symb_id}})")
-  base_module_func: (?<!\.)(?:BLAS\.(?:asum|blascopy!|dotc|dotu|gbmv|gbmv!|gemm|gemm!|gemv|gemv!|ger!|hemm|hemm!|hemv|hemv!|her!|her2k|her2k!|herk|herk!|iamax|nrm2|sbmv|sbmv!|scal|scal!|symm|symm!|symv|symv!|syr!|syr2k|syr2k!|syrk|syrk!|trmm|trmm!|trmv|trmv!|trsm|trsm!|trsv|trsv!)|Base\.(?:abs|abs2|abspath|accept|acos|acosd|acosh|acot|acotd|acoth|acsc|acscd|acsch|addprocs|airy|airyai|airyaiprime|airybi|airybiprime|airyprime|airyx|all|all!|allunique|angle|any|any!|append!|apropos|ascii|asec|asecd|asech|asin|asind|asinh|assert|asyncmap|atan|atan2|atand|atanh|atexit|atreplinit|backtrace|base|base64decode|base64encode|basename|besselh|besselhx|besseli|besselix|besselj|besselj0|besselj1|besseljx|besselk|besselkx|bessely|bessely0|bessely1|besselyx|beta|bfft|bfft!|big|bin|bind|binomial|bitbroadcast|bitpack|bitrand|bits|bitunpack|bkfact|bkfact!|blas_set_num_threads|blkdiag|brfft|broadcast|broadcast!|broadcast!_function|broadcast_function|broadcast_getindex|broadcast_setindex!|bswap|bytes2hex|bytestring|call|cat|catalan|catch_backtrace|catch_stacktrace|cbrt|cd|ceil|cell|cfunction|cglobal|charwidth|checkbounds|checkindex|chmod|chol|cholfact|cholfact!|chomp|chop|chown|chr2ind|circshift|cis|clamp|clamp!|cld|clear!|clipboard|close|cmp|code_llvm|code_lowered|code_native|code_typed|code_warntype|collect|colon|combinations|complex|cond|condskeel|conj|conj!|connect|consume|contains|conv|conv2|convert|copy|copy!|copysign|cor|cos|cosc|cosd|cosh|cospi|cot|cotd|coth|count|count_ones|count_zeros|countfrom|countlines|countnz|cov|cp|cross|csc|cscd|csch|ctime|ctranspose|ctranspose!|cummax|cummin|cumprod|cumprod!|cumsum|cumsum!|cumsum_kbn|current_module|current_task|cycle|dawson|dct|dct!|dec|deconv|deepcopy|default_worker_pool|deg2rad|delete!|deleteat!|den|deserialize|det|detach|diag|diagind|diagm|diff|digamma|digits|digits!|dirname|disable_sigint|display|displayable|displaysize|div|divrem|done|dot|download|drop|dropzeros|dropzeros!|dump|e|eachindex|eachline|eachmatch|edit|eig|eigfact|eigfact!|eigmax|eigmin|eigs|eigvals|eigvals!|eigvecs|eltype|empty!|endof|endswith|enumerate|eof|eps|erf|erfc|erfcinv|erfcx|erfi|erfinv|error|esc|escape_string|eta|etree|eu|eulergamma|evalfile|exit|exp|exp10|exp2|expand|expanduser|expm|expm1|exponent|extrema|eye|factor|factorial|factorize|falses|fd|fdio|fetch|fft|fft!|fftshift|field_offset|fieldname|fieldnames|fieldoffset|fieldoffsets|filemode|filesize|fill|fill!|filt|filt!|filter|filter!|finalize|finalizer|find|findfirst|findin|findlast|findmax|findmax!|findmin|findmin!|findn|findnext|findnz|findprev|first|fld|fld1|fldmod|fldmod1|flipbits!|flipdim|flipsign|float|floor|flush|fma|foldl|foldr|foreach|frexp|full|fullname|functionloc|gamma|gc|gc_enable|gcd|gcdx|gensym|get|get!|get_bigfloat_precision|get_rounding|get_zero_subnormals|getaddrinfo|gethostname|getindex|getipaddr|getkey|getpid|getsockname|givens|golden|gperm|gradient|graphemes|hankelh1|hankelh1x|hankelh2|hankelh2x|hash|haskey|hcat|hessfact|hessfact!|hex|hex2bytes|hex2num|hist|hist!|hist2d|hist2d!|histrange|homedir|htol|hton|hvcat|hypot|idct|idct!|identity|ifelse|ifft|ifft!|ifftshift|ignorestatus|im|imag|in|include|include_dependency|include_string|ind2chr|ind2sub|indexin|indexpids|indices|indmax|indmin|info|init_worker|insert!|instances|interrupt|intersect|intersect!|inv|invdigamma|invmod|invperm|ipermute!|ipermutedims|irfft|is_apple|is_assigned_char|is_bsd|is_linux|is_unix|is_windows|isabspath|isalnum|isalpha|isapprox|isascii|isassigned|isbits|isblockdev|ischardev|iscntrl|isconst|isdiag|isdigit|isdir|isdirpath|isempty|isequal|iseven|isexecutable|isfifo|isfile|isfinite|isgeneric|isgraph|ishermitian|isimag|isimmutable|isinf|isinteger|isinteractive|isleaftype|isless|islink|islocked|islower|ismarked|ismatch|ismount|isnan|isnull|isnumber|isodd|isopen|ispath|isperm|isposdef|isposdef!|ispow2|isprime|isprint|ispunct|isqrt|isreadable|isreadonly|isready|isreal|issetgid|issetuid|issocket|issorted|isspace|issparse|issticky|issubnormal|issubset|issym|issymmetric|istaskdone|istaskstarted|istext|istextmime|istril|istriu|isupper|isvalid|iswritable|isxdigit|join|joinpath|keys|keytype|kill|kron|last|launch|lbeta|lcfirst|lcm|ldexp|ldltfact|ldltfact!|leading_ones|leading_zeros|length|less|levicivita|lexcmp|lexless|lfact|lgamma|linearindices|linreg|linspace|listen|listenany|localindexes|lock|log|log10|log1p|log2|logabsdet|logdet|logm|logspace|lowercase|lpad|lq|lqfact|lqfact!|lstat|lstrip|ltoh|lu|lufact|lufact!|lyap|macroexpand|manage|map|map!|mapfoldl|mapfoldr|mapreduce|mapreducedim|mapslices|mark|match|matchall|max|maxabs|maxabs!|maximum|maximum!|maxintfloat|mean|mean!|median|median!|merge|merge!|method_exists|methods|methodswith|middle|midpoints|mimewritable|min|minabs|minabs!|minimum|minimum!|minmax|mkdir|mkpath|mktemp|mktempdir|mod|mod1|mod2pi|modf|module_name|module_parent|mtime|muladd|mv|myid|names|nb_available|ndigits|ndims|next|nextfloat|nextind|nextpow|nextpow2|nextprod|nnz|nonzeros|norm|normalize|normalize!|normalize_string|normpath|notify|now|nprocs|nthperm|nthperm!|ntoh|ntuple|nullspace|num|num2hex|nworkers|nzrange|object_id|oct|oftype|one|ones|open|operm|ordschur|ordschur!|parent|parentindexes|parity|parse|parseip|partitions|peakflops|permutations|permute|permute!|permutedims|permutedims!|pi|pinv|pipeline|plan_bfft|plan_bfft!|plan_brfft|plan_dct|plan_dct!|plan_fft|plan_fft!|plan_idct|plan_idct!|plan_ifft|plan_ifft!|plan_irfft|plan_rfft|pmap|pointer|pointer_from_objref|pointer_to_array|pointer_to_string|poll_fd|poll_file|polygamma|pop!|popdisplay|position|powermod|precision|precompile|prepend!|prevfloat|prevind|prevpow|prevpow2|prevprod|primes|primesmask|print|print_escaped|print_joined|print_shortest|print_unescaped|print_with_color|println|process_exited|process_running|procs|prod|prod!|produce|promote|promote_rule|promote_shape|promote_type|push!|pushdisplay|put!|pwd|qr|qrfact|qrfact!|quadgk|quantile|quantile!|quit|rad2deg|rand|rand!|randcycle|randexp|randexp!|randjump|randn|randn!|randperm|randstring|randsubseq|randsubseq!|range|rank|rationalize|read|read!|readall|readandwrite|readavailable|readbytes|readbytes!|readchomp|readcsv|readdir|readdlm|readline|readlines|readlink|readstring|readuntil|real|realmax|realmin|realpath|recv|recvfrom|redirect_stderr|redirect_stdin|redirect_stdout|redisplay|reduce|reducedim|reenable_sigint|reim|reinterpret|reload|relpath|rem|rem1|remote|remotecall|remotecall_fetch|remotecall_wait|repeat|repeated|replace|repmat|repr|reprmime|reset|reshape|resize!|rest|rethrow|retry|reverse|reverse!|reverseind|rfft|rm|rmprocs|rol|rol!|ror|ror!|rot180|rotl90|rotr90|round|rounding|rowvals|rpad|rsearch|rsearchindex|rsplit|rstrip|run|scale|scale!|schedule|schur|schurfact|schurfact!|sdata|search|searchindex|searchsorted|searchsortedfirst|searchsortedlast|sec|secd|sech|seek|seekend|seekstart|select|select!|selectperm|selectperm!|send|serialize|set_bigfloat_precision|set_rounding|set_zero_subnormals|setdiff|setdiff!|setenv|setindex!|setprecision|setrounding|shift!|show|showall|showcompact|showcompact_lim|showerror|shuffle|shuffle!|sign|signbit|signed|signif|significand|similar|sin|sinc|sind|sinh|sinpi|size|sizehint!|sizeof|skip|skipchars|sleep|slice|slicedim|sort|sort!|sortcols|sortperm|sortperm!|sortrows|sparse|sparsevec|spawn|spdiagm|specialized_binary|specialized_bitwise_binary|specialized_bitwise_unary|specialized_unary|speye|splice!|split|splitdir|splitdrive|splitext|spones|sprand|sprandbool|sprandn|sprint|spzeros|sqrt|sqrtm|squeeze|srand|stacktrace|start|startswith|stat|std|stdm|step|stride|strides|string|stringmime|strip|strwidth|sub|sub2ind|subtypes|success|sum|sum!|sum_kbn|sumabs|sumabs!|sumabs2|sumabs2!|summary|super|supertype|svd|svdfact|svdfact!|svds|svdvals|svdvals!|sylvester|symbol|symdiff|symdiff!|symlink|symperm|systemerror|take|take!|takebuf_array|takebuf_string|tan|tand|tanh|task_local_storage|tempdir|tempname|tic|time|time_ns|timedwait|toc|toq|touch|trace|trailing_ones|trailing_zeros|trailingsize|transcode|transpose|transpose!|trigamma|tril|tril!|triu|triu!|trues|trunc|truncate|trylock|tryparse|typeintersect|typejoin|typemax|typemin|ucfirst|unescape_string|union|union!|unique|unlock|unmark|unsafe_copy!|unsafe_load|unsafe_pointer_to_objref|unsafe_read|unsafe_store!|unsafe_string|unsafe_trunc|unsafe_wrap|unsafe_write|unshift!|unsigned|uperm|uppercase|utf8|valtype|values|var|varm|vcat|vec|vecdot|vecnorm|versioninfo|view|wait|walkdir|warn|watch_file|which|whos|widemul|widen|with_bigfloat_precision|with_rounding|withenv|workers|workspace|write|writecsv|writedlm|xcorr|xdump|yield|yieldto|zero|zeros|zeta|zip)|Collections\.(?:dequeue!|enqueue!|heapify|heapify!|heappop!|heappush!|isheap|peek)|Dates\.(?:adjust|datetime2julian|datetime2rata|datetime2unix|day|dayabbr|dayname|dayofmonth|dayofquarter|dayofweek|dayofweekofmonth|dayofyear|daysinmonth|daysinyear|daysofweekinmonth|firstdayofmonth|firstdayofquarter|firstdayofweek|firstdayofyear|hour|isleapyear|julian2datetime|lastdayofmonth|lastdayofquarter|lastdayofweek|lastdayofyear|millisecond|minute|month|monthabbr|monthday|monthname|now|quarterofyear|rata2datetime|recur|second|today|tofirst|tolast|tonext|toprev|unix2datetime|week|year|yearmonth|yearmonthday)|Docs\.(?:apropos|doc)|FFTW\.(?:dct|dct!|export_wisdom|fftwComplex|fftwNumber|fftwReal|flops|forget_wisdom|idct|idct!|import_system_wisdom|import_wisdom|plan_dct|plan_dct!|plan_idct|plan_idct!|plan_r2r|plan_r2r!|r2r|r2r!)|LAPACK\.(?:)|LibGit2\.(?:with)|Libc\.(?:calloc|errno|flush_cstdio|free|gethostname|getpid|malloc|realloc|strerror|strftime|strptime|systemsleep|time|transcode)|Libdl\.(?:dlclose|dlext|dllist|dlopen|dlopen_e|dlpath|dlsym|dlsym_e|find_library)|LinAlg\.(?:axpy!|bkfact|bkfact!|chol|cholfact|cholfact!|cond|condskeel|copy!|cross|ctranspose|det|diag|diagind|diagm|diff|dot|eig|eigfact|eigfact!|eigmax|eigmin|eigs|eigvals|eigvals!|eigvecs|expm|eye|factorize|givens|gradient|hessfact|hessfact!|isdiag|ishermitian|isposdef|isposdef!|issymmetric|istril|istriu|kron|ldltfact|ldltfact!|linreg|logabsdet|logdet|logm|lq|lqfact|lqfact!|lu|lufact|lufact!|lyap|norm|normalize|normalize!|nullspace|ordschur|ordschur!|peakflops|pinv|qr|qrfact|qrfact!|rank|scale!|schur|schurfact|schurfact!|sqrtm|svd|svdfact|svdfact!|svds|svdvals|svdvals!|sylvester|trace|transpose|tril|tril!|triu|triu!|vecdot|vecnorm)|Markdown\.(?:html|latex|license|readme)|Meta\.(?:isexpr|quot|show_sexpr)|Mmap\.(?:)|Operators\.(?:colon|ctranspose|getindex|hcat|hvcat|setindex!|transpose|vcat)|Pkg\.(?:add|available|build|checkout|clone|dir|free|init|installed|pin|resolve|rm|setprotocol!|status|test|update)|Profile\.(?:)|Serializer\.(?:deserialize|serialize)|SparseArrays\.(?:blkdiag|dense|droptol!|dropzeros|dropzeros!|issparse|nnz|nonzeros|nzrange|permute|rowvals|sparse|sparsevec|spdiagm|speye|spones|sprand|sprandn|spzeros|symperm)|StackTraces\.(?:catch_stacktrace|stacktrace)|Sys\.(?:cpu_info|cpu_name|cpu_summary|free_memory|loadavg|total_memory|uptime)|Test\.(?:detect_ambiguities)|Threads\.(?:atomic_add!|atomic_and!|atomic_cas!|atomic_fence|atomic_max!|atomic_min!|atomic_nand!|atomic_or!|atomic_sub!|atomic_xchg!|atomic_xor!|nthreads|threadid)|Core\.(?:applicable|eval|fieldtype|getfield|invoke|is|isa|isdefined|issubtype|nfields|nothing|setfield!|throw|tuple|typeassert|typeof))(?!{{symb_id}})
+# (issue 9, 16)
+  !β!(x)
+# ^ keyword.operator
+#  ^^ variable.function
+#     ^ variable.other
+  (x,f(x))
+#  ^ variable.other
+#    ^ variable.function
+#      ^ variable.other
+  √(2.3)
+# ^ variable.function
+#   ^^^ constant.numeric
+  TypeConstructor{Foo()}(a)
+# ^^^^^^^^^^^^^^^ variable.function
+#                ^^^^^^^ support.type
+#                        ^ variable.other
 
-  # Symbols part of the language syntax
-  symb_lang: (?:[(){}\[\],.;:'"`@#])
+# (issue 30)
+  f(a, ")=") a
+# ^ variable.function
+#   ^ variable.other
+#      ^^^^ string.quoted.double
+#            ^ variable.other
+  f(a, a=")=") = a
+# ^ entity.name.function
+#   ^ variable.parameter
+#      ^ variable.parameter
+#       ^ keyword.operator
+#        ^^^^ string.quoted.double
+#              ^ keyword.operator
+#                ^ variable.other
+  f(a, a=(")=")) = a
+# ^ entity.name.function
+#   ^ variable.parameter
+#      ^ variable.parameter
+#       ^ keyword.operator
+#         ^^^^ string.quoted.double
+#                ^ keyword.operator
+#                  ^ variable.other
+  f(a, a=")=\"a") = a
+# ^ entity.name.function
+#   ^ variable.parameter
+#      ^ variable.parameter
+#       ^ keyword.operator
+#        ^^^ string.quoted.double
+#           ^^ constant.character.escape
+#             ^^ string.quoted.double
+#                 ^ keyword.operator
+#                   ^ variable.other
 
-  # General identifier symbol
-  symb_id: (?:[^\s{{symb_lang}}{{symb_op}}])
+# (issue 46)
+  f(x)
+# ^^^^ meta.function-call
+# ^ variable.function
+#   ^  meta.function-call.arguments
+  abs(x)
+# ^^^ support.function
+# ^^^ variable.function
+  f(x=1)
+# ^ variable.function
+#   ^ variable.parameter
+#    ^ keyword.operator.assignment
 
-  # Alternative to \b that works with unicode symbols
-  b: (?<=(?:^|\s|{{symb_lang}}|{{symb_op}}))
+# (issue 47)
+  Base
+# ^^^^ support.module
+  Pkg.foo()
+# ^^^ support.module
+#     ^^^ variable.function
+  Core.foo(x) = 2
+# ^^^^ support.module
+  filter!()
+# ^^^^^^^ support.function
+  length
+# ^^^^^^ support.function
+  Base.filter!()
+# ^^^^ support.module
+#      ^^^^^^^ support.function
+  Base.filter!
+# ^^^^ support.module
+#      ^^^^^^^ support.function
+  Base.length
+# ^^^^ support.module
+#      ^^^^^^ support.function
 
-  # Recursively match nested curly braces
-  # Must be wrapped in a matching group when used. It is best to do this explicitly when used (not here) to avoid confusion.
-  # This regex depends on atomic group and back reference recursion.
-  # Cannot match multi-line types, because sublime applies regexes line by line.
-  # TODO: Parse multi-line types separately with push/pop matching. Omg pls no! {nested_curly} is used in 10 places and push/pop would make the code very messy. Who uses multi-line types anyway?
-  nested_curly: '{(?>[^{}]+|\g<-1>)*}'
-  # Don't use the following ones for lookaheads! May lead to unwanted matches.
-  # These match unfinished nested braces, to highlight during typing.
-  nested_curly_sloppy: '(?:{(?>[^{}]+|\g<-1>)*}|\{[^\}\)\] ]*)'
-  nested_curly_and_round_sloppy: (?:(?>{(?>[^{}]+|\g<-1>)*}|\((?>[^()]+|\g<-1>)*\))|[\{\(][^\}\)\] ]*)
 
-  # Recursively match nested brackets (of any type) and strings
-  # Must be wrapped in a matching group when used. It is best to do this explicitly when used (not here) to avoid confusion.
-  # NOTE: Use of atomic groups speeds up parsing immensely.
-  string: '"(?>(?>\\"|[^"])*|\g<-1>)*"'
-  nested_brackets_and_strings: |-
-    (?x)
-    (?>
-       {(?>{{string}}|[^{}]+|\g<-1>)*}|
-      \((?>{{string}}|[^()]+|\g<-1>)*\)|
-      \[(?>{{string}}|[^\[\]]+|\g<-1>)*\]|
-      {{string}}
-    )
+##
+## UNICODE WORD BOUDARIES
+##
 
-  # Helpers for function declaration
-  type_comparison_regex: (\$?{{symb_id}}+({{nested_curly_and_round_sloppy}})?)\s*(<:|>:)\s*((?:(?!\.\.)(?:[$.]|{{symb_id}}))+({{nested_curly_and_round_sloppy}})?)
-  func_name_standard: |-
-    (?x)
-    (?!!)                     # Function name doesn't start with !
-    ([^\s{{symb_lang}}]+)     # Function name
-    ({{nested_curly}})?       # Match type annotation
-    (?=[\( ])
-  func_name_paren: |-
-    (?x)
-    \(                        # Function name is wrapped in parentheses
-    (?!!)                     # Function name doesn't start with !
-    (::)?                     # Function name can start with ::
-    ((?:                      # Rest of function name
-      ({{nested_curly}})|     # Match nested curly brackets
-      [^)]                    # or anything that doesn't close paren
-    )+)
-    \)
-    ({{nested_curly}})?       # Match type annotation
-    (?=\()
-  func_params: |-
-    (?x)
-    \(                        # Open function parameters
-    # We are lazy here and don't parse the exact form of a parameter list
-    # with types, default values, splats etc. It is not needed.
-    (
-      ({{nested_brackets_and_strings}})| # Match nested brackets, can occur in parameter default value etc.
-      [^(){}\[\]"]            # or anything that doesn't close the argument list
-    )*
-    \)                        # Close function parameters
-    (                         # Allow where keyword
-      \s*where\s+
-      (
-        {{type_comparison_regex}}|
-        {{nested_curly}}|
-        {{symb_id}}+
-      )
-    )*
-    \s*=(?!=)                 # Followed by exactly one equal sign
+# Unicode and numbers in names (issue 18)
+  β1 = 5
+# ^^ variable.other
+  β3(x)
+# ^^ variable.function
+  β2(x) = x
+# ^^ entity.name.function
+  ∇1 = 5
+# ^^ variable.other
+  ∇3(x)
+# ^^ variable.function
+  ∇2(∇2) = x
+# ^^ entity.name.function
+#    ^^ variable.parameter
 
-contexts:
-  main:
-    - include: declarations
-    - include: expressions
+# (issue 11)
+  a::B{C}=c()
+#  ^^ keyword.operator
+#    ^^^^ support.type
+#        ^ keyword.operator
+#         ^ variable.function
 
-  expressions:
-    - include: comments
-    - include: symbols
-    - include: type-annotation
-    - include: type-comparison
-    - include: literals
-    - include: operators
-    - include: strings
-    - include: keywords
-    - include: macros
-    - include: support-functions
-    - include: function-call
-    - include: anonymous-function
-    - include: variable
-    - include: nested_parens
-    - include: nested_squarebrackets
 
-  declarations:
-    - include: decl-func
-    - include: decl-func-assignment-form
-    - include: decl-type
-    - include: decl-macro
-    - include: decl-typealias
+##
+## SYMBOLS
+##
 
-  comments:
-    - match: '#='
-      push: comment-block
-    - match: '#.*'
-      scope: comment.line.number-sign.julia
+  :a.b
+# ^ keyword.operator
+#  ^ constant.other.symbol
+#    ^ variable.other
+# (issue 3)
+  ,:βa
+#  ^ keyword.operator
+#   ^^ constant.other.symbol
+  [:+]
+#  ^ keyword.operator
+#   ^ constant.other.symbol
+  (:∘)
+#  ^ keyword.operator
+#   ^ constant.other.symbol
+  :a!
+# ^ keyword.operator
+#  ^^ constant.other.symbol
+  :(:)
+# ^ keyword.operator
+#  ^ source.julia
+#    ^ source.julia
+  :(a)
+# ^ keyword.operator
+#  ^ source.julia
+#   ^ variable.other
+#      ^ source.julia
+  :++a
+# ^ keyword.operator
+#  ^^ constant.other.symbol
+#    ^ variable.other
+  :+a
+# ^ keyword.operator
+#  ^ constant.other.symbol
+#   ^ variable.other
+  :∘+a # Yes, this is correct, equivalent to +(:∘, a)
+# ^ keyword.operator
+#  ^ constant.other.symbol
+#   ^ keyword.operator
+#    ^ variable.other
+  :.///a
+# ^ keyword.operator
+#  ^^^ constant.other.symbol
+#     ^ keyword.operator
+#      ^ variable.other
+# (issue 43)
+  :function
+# ^ keyword.operator
+#  ^^^^^^^^ constant.other.symbol
 
-  comment-block:
-    - meta_scope: comment.block.number-sign-equals.julia
-    - match: '#='
-      push: comment-block
-    - match: '=#'
-      pop: true
+:.a
+:.+a
+:.∘a
+:++a
+:+++a
+:/a
+://a
+:///a
+:.///a
 
-  keywords:
-    - match: \b(begin|end|function|type|macro|quote|let|local|global|const|abstract|typealias|bitstype|immutable|module|baremodule|using|import|export|importall|in)\b
-      scope: keyword.other.julia
-    - match: \b(if|else|elseif|for|while|do|try|catch|finally|return|break|continue)\b
-      scope: keyword.control.julia
 
-  operators:
-    # Bang is not only an operator symbol, it can also be part of a function name, thus it is treated separately.
-    # Single quote is not only an operator symbol, it can also start a string. It is an operator if it is preceded by an identifier, dot, single-quote, right round bracket or right square bracket
-    - match: (\.?)(=)
-      captures:
-        1: keyword.operator.broadcast.julia
-        2: keyword.operator.assignment.julia
-    - match: (\.)({{symb_op}}|')
-      captures:
-        1: keyword.operator.broadcast.julia
-        2: keyword.operator.julia
-    - match: |-
-        (?x)
-        (
-          {{symb_op}}|
-          !|
-          (?<=
-            (
-              {{symb_id}}|
-              [.')\]]
-            )
-          )
-          '
-        )
-      scope: keyword.operator.julia
+##
+## TERNARY OPERATORS
+##
 
-  support-functions:
-    - match: '(?={{base_module_func}}\.?({{nested_curly}})?\()'
-      push:
-        - match: ({{base_modules}})\.
-          captures:
-            1: support.module.julia
-        - match: (?<=\.)({{symb_id}}+)
-          scope: variable.function.julia support.function.julia meta.function-call.julia
-          push: function-call-helper
-        - match: ''
-          pop: true
-    - match: '(?={{base_module_func}})'
-      push:
-        - match: ({{symb_id}}+)\.
-          captures:
-            1: support.module.julia
-        - match: (?<=\.)({{symb_id}}+)
-          scope: variable.function.julia support.function.julia
-        - match: ''
-          pop: true
+  a?b:c
+# ^ variable.other
+#  ^ keyword.operator
+#   ^ variable.other
+#    ^ keyword.operator
+#     ^ variable.other
+  a ? b :c
+# ^ variable.other
+#   ^ keyword.operator
+#     ^ variable.other
+#       ^ keyword.operator
+#        ^ variable.other
 
-  function-call:
-    - match: '(?<!\.)(?={{symb_id}}+\.?({{nested_curly}})?\()'
-      push:
-        - meta_content_scope: meta.function-call.julia
-        # Built-in function
-        - match: '{{base_funcs}}'
-          scope: variable.function.julia support.function.julia
-        - include: function-call-helper
-        - match: ''
-          pop: true
-    - match: '(?=({{symb_id}}+)\.?({{nested_curly}})?\()'
-      push: function-call-helper
 
-  function-call-helper:
-    - meta_content_scope: meta.function-call.julia
-    # Function
-    - match: '{{symb_id}}+'
-      scope: variable.function.julia
-    # Type
-    - match: ({{nested_curly}})
-      scope: support.type.julia
-    # Broadcast
-    - match: '\.'
-      scope: keyword.operator.broadcast.julia
-    # Begin arguments
-    - match: \(
-      set:
-        - meta_content_scope: meta.function-call.arguments.julia
-        - match: '({{symb_id}}+)\s*(=)'
-          captures:
-            1: variable.parameter.julia
-            2: keyword.operator.assignment.julia
-        - include: expressions
-        # End arguments and function call
-        - match: \)
-          scope: meta.function-call.julia
-          pop: true
+##
+## RANGES
+##
 
-  literals:
-    - match: |-
-        (?x)
-        (?: # Dashes betwen numeric symbols (11 = 1_1) are allowed everywhere.
-          {{b}}0b[0-1](?:_?[0-1])*|             # binary
-          {{b}}0o[0-7](?:_?[0-7])*|             # octal
-          {{b}}0x[\da-fA-F](?:_?[\da-fA-F])*|   # hex
-          {{b}}(?:
-            \.\d(?:_?\d)*|                      # .11, .11
-            \d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?  # 11.11, 11., 11
-          )
-          (?:e[-+]?\d(?:_?\d)*)?                # Any of the above followed by e+123 or similar, for scientific notation.
-        )
-      scope: constant.numeric.julia
-    - match: \b(true|false|nothing|NaN|Inf)\b
-      scope: constant.language.julia
+# (issue 14)
+  a:b
+# ^ variable.other
+#  ^ keyword.operator
+#   ^ variable.other
+  1.:a
+# ^^ constant.numeric
+#   ^ keyword.operator
+#    ^ variable.other
+  a:2.
+# ^ variable.other
+#  ^ keyword.operator
+#   ^^ constant.numeric
+  23.:31.
+# ^^^ constant.numeric
+#    ^ keyword.operator
+#     ^^^ constant.numeric
+  β:f()
+# ^ variable.other
+#  ^ keyword.operator
+#   ^ variable.function
+  f():1
+# ^ variable.function
+#    ^ keyword.operator
+#     ^ constant.numeric
 
-  type-annotation:
-    # Dollar is ok because types can be interpolated.
-    # Dot is ok because types can be picked from modules,
-    # but no more than one dot, because splat can follow type.
-    - match: (::)\s*((?:(?!\.\.)(?:[$.]|{{symb_id}}))*({{nested_curly_and_round_sloppy}})?)\s*(where)\s+
-      captures:
-        1: keyword.operator.julia
-        2: support.type.julia
-        4: keyword.other.julia
-      push: where-type
-    - match: (::|<:|>:)\s*((?:(?!\.\.)(?:[$.]|{{symb_id}}))*({{nested_curly_and_round_sloppy}})?)
-      captures:
-        1: keyword.operator.julia
-        2: support.type.julia
 
-  type-comparison:
-    - match: '{{type_comparison_regex}}'
-      captures:
-        1: support.type.julia
-        3: keyword.operator.julia
-        4: support.type.julia
+##
+## TYPES
+##
 
-  where-type:
-    - match: (\{){{type_comparison_regex}}(\})
-      captures:
-        1: support.type.julia
-        2: support.type.julia
-        4: keyword.operator.julia
-        5: support.type.julia
-        7: support.type.julia
-    - match: '{{type_comparison_regex}}'
-      captures:
-        1: support.type.julia
-        3: keyword.operator.julia
-        4: support.type.julia
-    - match: '({{nested_curly_sloppy}})'
-      scope: support.type.julia
-    - match: '{{symb_id}}+'
-      scope: support.type.julia
-    - match: \s*(where)\s+
-      captures:
-        1: keyword.other.julia
-      push: where-type
-    - match: ''
-      pop: true
+  f(x::Foo, ::Bar{1, 2})
+# ^ variable.function
+#   ^ variable.other
+#    ^^ keyword.operator
+#      ^^^ support.type
+#           ^^ keyword.operator
+#             ^^^^^^^^^ support.type
+# Nested types
+  x::A{B,C{D,E},F{G,H{I,J{K,L{M}},N}}} closed
+#  ^^ keyword.operator
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.type
+# (issue 19)
+  myvar::MyModule.MyType
+# ^^^^^ variable.other
+#      ^^ keyword.operator
+#        ^^^^^^^^^^^^^^^ support.type
 
-  decl-func:
-    - match: '\b(?<!:)(function)\s+(?!@)'
-      captures:
-        1: keyword.other.julia
-      push:
-        - meta_scope: meta.function.julia
-        - include: func-name-paren
-        - include: func-name-standard
-        # Anonymous function
-        - match: \(
-          set: function-parameters
-        # Function name on the form "Module.func"
-        - match: '([^.{(]+)(\.)'
-          captures:
-            1: variable.other.julia
-            2: keyword.operator.julia
+# Modules (issue 19)
+  MyModule.myfunc(x)
+# ^^^^^^^^ variable.other
+#          ^^^^^^ variable.function
+#                 ^ variable.other
 
-  anonymous-function:
-    - match: '(?=({{nested_brackets_and_strings}})\s*->)'
-      set: function-parameters
-    - match: '({{symb_id}}+)(::)?({{symb_id}}+)?({{nested_curly}})?\s*(->)'
-      captures:
-        1: variable.parameter
-        2: keyword.operator
-        3: support.type
-        4: support.type
-        5: keyword.operator
-    - match: '({{symb_id}}+)\s*(->)'
-      captures:
-        1: variable.parameter
-        2: keyword.operator
+# (issue 11)
+  aa::AA{BB} = fun{CC{DD}}()
+# ^^ variable.other
+#   ^^ keyword.operator
+#     ^^^^^^ support.type
+#            ^ keyword.operator
+#              ^^^ variable.function
+#                 ^^^^^^^^ support.type
+  aa::AA{BB}=fun{CC{DD}}() closed
+# ^^ variable.other
+#   ^^ keyword.operator
+#     ^^^^^^ support.type
+#           ^ keyword.operator
+#            ^^^ variable.function
+#               ^^^^^^^^ support.type
+#                          ^^^^^^ variable.other
+  mytype = Array
+# ^^^^^^ variable.other
+#        ^ keyword.operator
+#          ^^^^^ support.type
+  mytype = Array{Int}
+# ^^^^^^ variable.other
+#        ^ keyword.operator
+#          ^^^^^^^^^^ support.type
+  mytype = CallMsg{:call}
+#          ^^^^^^^^^^^^^^ support.type
 
-  # Do lookaheads to distinguish function calls from function definitions on assignment form
-  decl-func-assignment-form:
-    - match: |-
-        (?x)
-        (?=
-          {{func_name_paren}}
-          {{func_params}}
-        )
-      push: func-name-paren
-    - match: |-
-        (?x)
-        (?=
-          {{func_name_standard}}
-          {{func_params}}
-        )
-      push: func-name-standard
-    - match: |-
-        (?x)
-        (?=
-          (?!!)
-          ([^\s{{symb_lang}}]+\.)+
-          {{func_name_standard}}
-          {{func_params}}
-        )
-      push:
-        - match: '({{base_modules}})\.(?=[^\s{{symb_lang}}])'
-          captures:
-            1: support.module.julia
-          push: func-name-standard
-          pop: true
-        - match: '(([^\s{{symb_lang}}]+\.)+)(?=[^\s{{symb_lang}}])'
-          captures:
-            1: variable.other.julia
-          push: func-name-standard
-          pop: true
+# Julia 0.6 (issue 45)
+  A = Array{T} where T<:Integer{Foo}
+#     ^^^^^^^^ support.type
+#              ^^^^^ keyword.other
+#                    ^ support.type
+#                     ^^ keyword.operator
+#                       ^^^^^^^^^^^^ support.type
+  S >: T
+# ^ support.type
+#   ^^ keyword.operator
+#      ^ support.type
+  Foo <: $A{$A}
+# ^^^ support.type
+#     ^^ keyword.operator
+#        ^^^^^^ support.type
+  $A{$A} >: $A{$A}
+# ^^^^^^ support.type
+#        ^^ keyword.operator
+#           ^^^^^^ support.type
 
-  func-name-standard:
-    - match: '{{func_name_standard}}'
-      captures:
-        1: entity.name.function.julia
-        2: support.type.julia
-      set: function-parameters
+# (issue 17)
+# All things being defined are green, types as well
+  type Foo{T<:Real} end
+# ^^^^ keyword.other
+#      ^^^ entity.name.type
+#         ^^^^^^^^^ support.type
+  type A <: B end
+# ^^^^ keyword.other
+#      ^ entity.name.type
+#        ^^ keyword.operator
+#           ^ support.type
+#             ^^^ keyword.other
+  type Foo{T}<:Bar{T} end
+# ^^^^ keyword.other
+#      ^^^ entity.name.type
+#         ^^^ support.type
+#            ^^ keyword.operator
+#              ^^^^^^ support.type
+  immutable Foo{T<:Real} end
+# ^^^^^^^^^ keyword.other
+#           ^^^ entity.name.type
+#              ^^^^^^^^^ support.type
+  typealias Foo{T} Bar{T}
+# ^^^^^^^^^ keyword.other
+#           ^^^^^^ entity.name.type
+#                  ^^^^^^ support.type
+  bitstype 32 Foo{T}<:Bar{T}
+# ^^^^^^^^ keyword.other
+#          ^^ constant.numeric
+#             ^^^^^^ entity.name.type
+#                   ^^ keyword.operator
+#                     ^^^^^^ support.type
 
-  func-name-paren:
-    - match: '{{func_name_paren}}'
-      captures:
-        1: keyword.operator.julia
-        2: entity.name.function.julia
-        4: support.type.julia
-      set: function-parameters
+# Julia 0.6 (issue 45)
+  struct Foo{T} end
+# ^^^^^^ keyword.other
+#        ^^^ entity.name.type
+#           ^^^ support.type
+#               ^^^ keyword.other
+  mutable struct Foo{T} end
+# ^^^^^^^ keyword.other
+#         ^^^^^^ keyword.other
+#                ^^^ entity.name.type
+#                   ^^^ support.type
+#                       ^^^ keyword.other
+  abstract type Foo{T} end
+# ^^^^^^^^ keyword.other
+#          ^^^^ keyword.other
+#               ^^^ entity.name.type
+#                  ^^^ support.type
+#                      ^^^ keyword.other
+  primitive type Char 32 end
+# ^^^^^^^^^ keyword.other
+#           ^^^^ keyword.other
+#                ^^^^ entity.name.type
+#                     ^^ constant.numeric
+#                        ^^^ keyword.other
 
-  function-parameters:
-    - meta_content_scope: meta.function.parameters.julia
-    - match: end
-      scope: keyword.other
-      pop: true
-    - match: \)\s*(where)\s+
-      captures:
-        1: keyword.other
-      set: where-type
-    - match: \)
-      pop: true
-    - include: comments
-    - match: '='
-      scope: keyword.operator.assignment.julia
-      set:
-        - meta_scope: meta.function.parameters.default-value.julia
-        - match: '(?=[,;)])'
-          set: function-parameters
-        - include: expressions
-    - include: type-annotation
-    - match: \.\.\. # Splat after type
-      scope: keyword.operator.julia
-    - match: ({{symb_id}}+)(\.\.\.)?
-      captures:
-        1: variable.parameter.julia
-        2: keyword.operator.julia
+# (issue 52)
+  mutable struct $Foo{T} end
+# ^^^^^^^ keyword.other
+#         ^^^^^^ keyword.other
+#                ^^^^ entity.name.type
+#                    ^^^ support.type
+#                        ^^^ keyword.other
 
-  decl-macro:
-    - match: '\b(macro)\s+([^(]+)\('
-      captures:
-        1: keyword.other.julia
-        2: entity.name.macro.julia
-      set: function-parameters
 
-  decl-type:
-    # Dollar is ok because type names can be interpolated.
-    - match: \b(?:(mutable)\s+(struct)|(abstract)\s+(type)|(primitive)\s+(type))\s+((?:\$|{{symb_id}})+)({{nested_curly}})?
-      scope: meta.type.julia
-      captures: # Make this less repetitive?
-        1: keyword.other.julia
-        2: keyword.other.julia
-        3: keyword.other.julia
-        4: keyword.other.julia
-        5: keyword.other.julia
-        6: keyword.other.julia
-        7: entity.name.type.julia
-        8: support.type.julia
-    - match: \b(type|struct|immutable|abstract)\s+((?:\$|{{symb_id}})+)({{nested_curly}})?
-      scope: meta.type.julia
-      captures:
-        1: keyword.other.julia
-        2: entity.name.type.julia
-        3: support.type.julia
-    - match: \b(bitstype)\s+(\d+)\s+({{symb_id}}+({{nested_curly}})?)
-      captures:
-        1: keyword.other.julia
-        2: constant.numeric.julia
-        3: entity.name.type.julia
+##
+## FUNCTION DEFINITIONS
+##
 
-  decl-typealias: # DEPRECATED 0.6
-    - match: \b(typealias)\s+({{symb_id}}+)({{nested_curly}})?\s+({{symb_id}}+({{nested_curly}})?)?
-      captures:
-        1: keyword.other.julia
-        2: entity.name.type.julia
-        3: entity.name.type.julia # Duplication because {{nested_curly}} must be wrapped in a matching group
-        4: support.type.julia
+  function f(a::b) end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^ keyword.operator
+#               ^ support.type
+#                  ^^^ keyword.other
 
-  symbols:
-    # This is slightly more involved than what one might first expect
-    # because, for example, in `:aa` the symbol is `aa` but in `:+a` only `+` is the symbol.
-    # Also take some extra steps to not mess up ternary a?b:c syntax.
-    - match: |-
-        (?x)
-        (?<! {{symb_id}}: )   # Not preceded by `a:`
-        (?<! {{symb_id}}\s: ) # or `a :` (How to match multiple spaces in lookbehind?)
-        (?<! [<)}\].'"]: )    # or other symbol-blocking chars.
-        (?<=:)                # Preceeded by colon.
-        (                     # The actual symbol can be a
-          (\.?{{long_op}})|   # (dotted) multi-character-operator
-          (\.?{{symb_op}})|   # (dotted) operator
-          @?{{symb_id}}*      # variable (or macro) name
-        )
-      scope: constant.other.symbol.julia
+  function Module.foo!{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) end
+# ^^^^^^^^ keyword.other
+#          ^^^^^^ variable.other
+#                ^ keyword.operator
+#                 ^^^^ entity.name.function
+#                     ^^^^^^^^^ support.type
+#                               ^^ variable.parameter
+#                                 ^^ keyword.operator
+#                                   ^^^^^^ support.type
+#                                           ^ variable.parameter
+#                                            ^^ keyword.operator
+#                                              ^^^^^^ support.type
+#                                                    ^ keyword.operator
+#                                                     ^^ constant.numeric
+#                                                       ^^ keyword.operator
+#                                                         ^^^^^^ support.type
+#                                                                 ^ variable.parameter
+#                                                                    ^^^ keyword.other
 
-  macros:
-    - match: '@{{symb_id}}+\b'
-      # Julians want their macros to light up as functions by default
-      # The scope `variable.macro` is applied last to give it precedence
-      # so that user can override the color in the color theme.
-      scope: support.function.julia variable.macro.julia
+# Infix operator declaration
+  function ∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#           ^^^^^^^^^ support.type
+#                     ^^ variable.parameter
+#                       ^^ keyword.operator
+#                         ^^^^^^ support.type
+#                                 ^ variable.parameter
+#                                  ^^ keyword.operator
+#                                    ^^^^^^ support.type
+#                                          ^ keyword.operator
+#                                           ^^ constant.numeric
+#                                             ^^ keyword.operator
+#                                               ^^^^^^ support.type
+#                                                       ^ variable.parameter
+#                                                          ^^^ keyword.other
 
-  variable:
-    - match: '({{symb_id}}+({{nested_curly_sloppy}})?)\s*(where)\s+'
-      captures:
-        1: support.type.julia
-        3: keyword.other.julia
-      push: where-type
-    - match: '{{symb_id}}+({{nested_curly_sloppy}})'
-      scope: support.type.julia
-    - match: '{{base_types}}'
-      scope: support.type.julia
-    - match: '{{base_funcs}}'
-      scope: variable.function.julia support.function.julia
-    - match: '(?<!\.){{base_modules}}'
-      scope: support.module.julia
-    - match: '{{symb_id}}+'
-      scope: variable.other.julia
+# Infix operator declaration in module
+  function Module.∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) end
+# ^^^^^^^^ keyword.other
+#          ^^^^^^ variable.other
+#                ^ keyword.operator
+#                 ^ entity.name.function
+#                  ^^^^^^^^^ support.type
+#                            ^^ variable.parameter
+#                              ^^ keyword.operator
+#                                ^^^^^^ support.type
+#                                        ^ variable.parameter
+#                                         ^^ keyword.operator
+#                                           ^^^^^^ support.type
+#                                                 ^ keyword.operator
+#                                                  ^^ constant.numeric
+#                                                    ^^ keyword.operator
+#                                                      ^^^^^^ support..type
+#                                                              ^ variable.parameter
+#                                                                 ^^^ keyword.other
 
-  strings:
-    # Regex string, tripple-quoted. Has special escaping and no string interpolation.
-    - match: '\br"""'
-      push:
-      - meta_scope: string.quoted.other.julia
-      - match: (\\"|\\\\)
-        scope: constant.character.escape.julia
-      - match: '"""'
-        pop: true
-    # Regex string. Has special escaping and no string interpolation.
-    - match: '\br"'
-      push:
-      - meta_scope: string.quoted.other.julia
-      - match: (\\"|\\\\)
-        scope: constant.character.escape.julia
-      - match: '"'
-        pop: true
-    # Triple double-quoted string
-    - match: '"""'
-      push: string-triple-content
-    # Double-quoted
-    - match: '"'
-      push: string-standard-content
-    # Prefixed double-quoted
-    - match: '{{symb_id}}+"'
-      push:
-      - meta_scope: string.quoted.other.julia
-      - include: string-escape
-      - match: '"'
-        pop: true
-    # Single-quoted string
-    - match: "'"
-      push:
-      - meta_scope: string.quoted.single.julia
-      - include: string-escape
-      - match: "'"
-        pop: true
-    # Cmd string
-    - match: '`'
-      push: string-cmd-content
+# Assignemetn-form function declaration (issue 19)
+  MyModule.foo!{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) = kron(a, b)
+# ^^^^^^^^ variable.other
+#          ^^^^ entity.name.function
+#              ^^^^^^^^^ support.type
+#                        ^^ variable.parameter
+#                          ^^ keyword.operator
+#                            ^^^^^^ support.type
+#                                    ^ variable.parameter
+#                                     ^^ keyword.operator
+#                                       ^^^^^^ support.type
+#                                             ^ keyword.operator
+#                                              ^^ constant.numeric
+#                                                ^^ keyword.operator
+#                                                  ^^^^^^ support.type
+#                                                          ^ variable.parameter
+#                                                             ^ keyword.operator
 
-  string-escape:
-    - match: \\(\\|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8}|.)
-      scope: constant.character.escape.julia
+# Assignemetn-form infix operator declaration
+  ∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) = ...
+# ^ entity.name.function
+#  ^^^^^^^^^ support.type
+#            ^^ variable.parameter
+#              ^^ keyword.operator
+#                ^^^^^^ support.type
+#                        ^ variable.parameter
+#                         ^^ keyword.operator
+#                           ^^^^^^ support.type
+#                                 ^ keyword.operator
+#                                  ^^ constant.numeric
+#                                    ^^ keyword.operator
+#                                      ^^^^^^ support.type
+#                                              ^ variable.parameter
+#                                                 ^ keyword.operator
 
-  string-standard-content:
-    - meta_scope: string.quoted.double.julia
-    - match: '"'
-      pop: true
-    - include: string-escape
-    - match: \$
-      scope: keyword.operator.julia
-      set: string-standard-interpolation
+# Assignemetn-form infix operator declaration in module
+  MyModule.∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) = ...
+# ^^^^^^^^ variable.other
+#          ^ entity.name.function
+#           ^^^^^^^^^  support.type
+#                     ^^ variable.parameter
+#                       ^^ keyword.operator
+#                         ^^^^^^  support.type
+#                                 ^ variable.parameter
+#                                  ^^ keyword.operator
+#                                    ^^^^^^  support.type
+#                                          ^ keyword.operator
+#                                           ^^ constant.numeric
+#                                             ^^ keyword.operator
+#                                               ^^^^^^ support.type
+#                                                       ^ variable.parameter
+#                                                          ^ keyword.operator
 
-  string-standard-interpolation:
-    - match: (?<=\))
-      set: string-standard-content
-    - include: nested_parens
-    - match: '{{symb_id}}+'
-      scope: variable.other.julia
-      set:
-        - match: ''
-          set: string-standard-content
+# (issue 23)
+  f(a::B{()}) = ...
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^^ keyword.operator
+#      ^^^^^ support.type
+#             ^ keyword.operator
 
-  string-triple-content:
-    - meta_scope: string.quoted.double.julia
-    - match: '"""'
-      pop: true
-    - include: string-escape
-    - match: \$
-      scope: keyword.operator.julia
-      set: string-triple-interpolation
+# Splats and interpolated types
+  f(x..., x::$Foo..., a=a) = ...
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^^^ keyword.operator
+#         ^ variable.parameter
+#          ^^ keyword.operator
+#            ^^^^ support.type
+#                ^^^ keyword.operator
+#                     ^ variable.parameter
+#                      ^ keyword.operator
+#                       ^ variable.other
+  function f(x..., x::$Foo{$T}..., a=a) end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^^ keyword.operator
+#                  ^ variable.parameter
+#                   ^^ keyword.operator
+#                     ^^^^^^^^ support.type
+#                             ^^^ keyword.operator
+#                                  ^ variable.parameter
+#                                   ^ keyword.operator
+#                                    ^ variable.other
+#                                       ^^^ keyword.other
 
-  string-triple-interpolation:
-    - match: (?<=\))
-      set: string-triple-content
-    - include: nested_parens
-    - match: '{{symb_id}}+'
-      scope: variable.other.julia
-      set:
-        - match: ''
-          set: string-triple-content
+# Parenthesized function name
+  function (a)(b) end
+# ^^^^^^^^ keyword.other
+#           ^ entity.name.function
+#              ^ variable.parameter
+#                 ^^^ keyword.other
+  function (+)(a) end
+# ^^^^^^^^ keyword.other
+#           ^ entity.name.function
+#              ^ variable.parameter
+#                 ^^^ keyword.other
+  (+)(a, b) = ...
+#  ^ entity.name.function
+#     ^ variable.parameter
+#        ^ variable.parameter
+#           ^ keyword.operator
 
-  string-cmd-content:
-    - meta_scope: string.quoted.cmd.julia
-    - match: '`'
-      pop: true
-    - include: string-escape
-    - match: \$
-      scope: keyword.operator.julia
-      set: string-cmd-interpolation
+# Anonymous function
+  function (a) foo end
+# ^^^^^^^^ keyword.other
+#           ^ variable.parameter
+#              ^^^ variable.other
+#                  ^^^ keyword.other
 
-  string-cmd-interpolation:
-    - match: (?<=\))
-      set: string-cmd-content
-    - include: nested_parens
-    - match: '{{symb_id}}+'
-      scope: variable.other.julia
-      set:
-        - match: ''
-          set: string-cmd-content
+# Type constructor
+ (::Type{Foo{A}}){B}(a::Bar{B}) = ...
+# ^^ keyword.operator
+#   ^^^^^^^^^^^^ entity.name.function
+#                ^^^ support.type
+#                    ^ variable.parameter
+#                     ^^ keyword.operator
+#                       ^^^^^^ support.type
+  function (::Type{Foo{A}}){B}(a::Bar{b})
+# ^^^^^^^^ keyword.other
+#           ^^ keyword.operator
+#             ^^^^^^^^^^^^ entity.name.function
+#                          ^^^ support.type
+#                              ^ variable.parameter
+#                               ^^ keyword.operator
+#                                 ^^^^^^ support.type
+  f(a="()") = a
+# ^ entity.name.function
+#   ^ variable.parameter
+#     ^^^^ string.quoted
+#           ^ keyword.operator
+#             ^ variable.other
 
-  nested_parens:
-    - match: \(
-      push:
-        - match: \)
-          pop: true
-        - include: declarations
-        - include: expressions
+  (::f{A()}){A{B()}}(a) = ...
+#  ^^ keyword.operator
+#    ^^^^^^ entity.name.function
+#           ^^^^^^^^ support.type
+#                    ^ variable.parameter
 
-  nested_squarebrackets:
-    - match: \[
-      push:
-        - match: \]
-          pop: true
-        - include: expressions
+  f(a=[b,c]) = d
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^ keyword.operator
+#      ^ variable.other
+#        ^ variable.other
+#            ^ keyword.operator
+#              ^ variable.other
+
+# (issue 31)
+  f(x::A=5; z) = ...
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^^ keyword.operator
+#      ^ support.type
+#       ^ keyword.operator
+#        ^ constant.numeric
+#           ^ variable.parameter
+
+# (issue 33)
+  f(::Int, x::Float64) = x
+# ^ entity.name.function
+#   ^^ keyword.operator
+#     ^^^ support.type
+#          ^variable.parameter
+#           ^^ keyword.operator
+#             ^^^^^^^ support.type
+
+  f(; x::Float64) = x
+# ^ entity.name.function
+#     ^ variable.parameter
+#      ^^ keyword.operator
+#        ^^^^^^^ support.type
+
+# The following fails, function parameters should be highlighted.
+# There seems to be no way of solving this, see issue #33.
+  f(x,
+    y) = ...
+# Tests are removed, to avoid superfluous test fails (comments are ignored).
+
+# (issue 40)
+  function foo end
+# ^^^^^^^^ keyword.other
+#          ^^^ entity.name.function
+#              ^^^ keyword.other
+  function foo (x) end
+# ^^^^^^^^ keyword.other
+#          ^^^ entity.name.function
+#               ^ variable.parameter
+#                  ^^^ keyword.other
+
+# Jula 0.6 (issue 45)
+  function inv(M::Matrix{T}) where T<:AbstractFloat end
+# ^^^^^^^^ keyword.other
+#          ^^^ entity.name.function
+#              ^ variable.parameter
+#               ^^ keyword.operator
+#                 ^^^^^^^^^ support.type
+#                            ^^^^^ keyword.other
+#                                  ^  support.type
+#                                   ^^ keyword.operator
+#                                     ^^^^^^^^^^^^^ support.type
+#                                                   ^^^ keyword.other
+  function inv(M::Matrix{T} where T<:AbstractFloat) end
+# ^^^^^^^^ keyword.other
+#          ^^^ entity.name.function
+#              ^ variable.parameter
+#               ^^ keyword.operator
+#                 ^^^^^^^^^ support.type
+#                           ^^^^^ keyword.other
+#                                 ^  support.type
+#                                  ^^ keyword.operator
+#                                    ^^^^^^^^^^^^^ support.type
+#                                                   ^^^ keyword.other
+  inv(M::Matrix{T}) where T<:AbstractFloat = M
+# ^^^ entity.name.function
+#     ^ variable.parameter
+#      ^^ keyword.operator
+#        ^^^^^^^^^ support.type
+#                   ^^^^^ keyword.other
+#                         ^  support.type
+#                          ^^ keyword.operator
+#                            ^^^^^^^^^^^^^ support.type
+#                                          ^ keyword.operator
+  inv(M::Matrix{T}) where {T<:AbstractFloat} = M
+# ^^^ entity.name.function
+#     ^ variable.parameter
+#      ^^ keyword.operator
+#        ^^^^^^^^^ support.type
+#                   ^^^^^ keyword.other
+#                         ^^  support.type
+#                           ^^ keyword.operator
+#                             ^^^^^^^^^^^^^^ support.type
+#                                            ^ keyword.operator
+  inv(M::Matrix{T} where T<:AbstractFloat) = M
+# ^^^ entity.name.function
+#     ^ variable.parameter
+#      ^^ keyword.operator
+#        ^^^^^^^^^ support.type
+#                  ^^^^^ keyword.other
+#                        ^  support.type
+#                         ^^ keyword.operator
+#                           ^^^^^^^^^^^^^ support.type
+#                                          ^ keyword.operator
+  inv(M::Matrix{T} where {T<:AbstractFloat}) = M
+# ^^^ entity.name.function
+#     ^ variable.parameter
+#      ^^ keyword.operator
+#        ^^^^^^^^^ support.type
+#                  ^^^^^ keyword.other
+#                        ^^  support.type
+#                          ^^ keyword.operator
+#                            ^^^^^^^^^^^^^^ support.type
+#                                            ^ keyword.operator
+  f(x::Array{T,S} where T) = x
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^^ keyword.operator
+#      ^^^^^^^^^^ support.type
+#                 ^^^^^ keyword.other
+#                       ^ support.type
+#                          ^ keyword.operator
+  f(x::Array{T,S} where T where S) = x
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^^ keyword.operator
+#      ^^^^^^^^^^ support.type
+#                 ^^^^^ keyword.other
+#                       ^ support.type
+#                         ^^^^^ keyword.other
+#                               ^ support.type
+#                                  ^ keyword.operator
+  f(x::Array{T,S}) where T = x
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^^ keyword.operator
+#      ^^^^^^^^^^ support.type
+#                  ^^^^^ keyword.other
+#                        ^ support.type
+#                          ^ keyword.operator
+  f(x::Array{T,S}) where T where S = x
+# ^ entity.name.function
+#   ^ variable.parameter
+#    ^^ keyword.operator
+#      ^^^^^^^^^^ support.type
+#                  ^^^^^ keyword.other
+#                        ^ support.type
+#                          ^^^^^ keyword.other
+#                                ^ support.type
+#                                  ^ keyword.operator
+  function f(x::Array{T,S}) where T end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^ keyword.operator
+#               ^^^^^^^^^^ support.type
+#                           ^^^^^ keyword.other
+#                                 ^ support.type
+#                                   ^^^ keyword.other
+  function f(x::Array{T,S}) where T where S end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^ keyword.operator
+#               ^^^^^^^^^^ support.type
+#                           ^^^^^ keyword.other
+#                                 ^ support.type
+#                                   ^^^^^ keyword.other
+#                                         ^ support.type
+#                                           ^^^ keyword.other
+  function f(x::Array{T,S} where T) end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^ keyword.operator
+#               ^^^^^^^^^^ support.type
+#                          ^^^^^ keyword.other
+#                                ^ support.type
+#                                   ^^^ keyword.other
+  function f(x::Array{T,S} where T where S) end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^ keyword.operator
+#               ^^^^^^^^^^ support.type
+#                          ^^^^^ keyword.other
+#                                ^ support.type
+#                                  ^^^^^ keyword.other
+#                                        ^ support.type
+#                                           ^^^ keyword.other
+  function f(x::typeof(yy) where T where S) end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^ keyword.operator
+#               ^^^^^^^^^^ support.type
+#                          ^^^^^ keyword.other
+#                                ^ support.type
+#                                  ^^^^^ keyword.other
+#                                        ^ support.type
+#                                           ^^^ keyword.other
+  function *(x::Bool, y::T)::promote_type(Bool,T) where T<:Unsigned end
+# ^^^^^^^^ keyword.other
+#          ^ entity.name.function
+#            ^ variable.parameter
+#             ^^ keyword.operator
+#               ^^^^ support.type
+#                     ^ variable.parameter
+#                      ^^ keyword.operator
+#                        ^ support.type
+#                          ^^ keyword.operator
+#                            ^^^^^^^^^^^^^^^^^^^^ support.type
+#                                                 ^^^^^ keyword.other
+#                                                       ^ support.type
+#                                                        ^^ keyword.operator
+#                                                          ^^^^^^^^ support.type
+#                                                                   ^^^ keyword.other
+
+# Anonymous functions
+  (x::T{S}, yy::T{S}) ->
+#  ^ variable.parameter
+#   ^^ keyword.operator
+#     ^^^^ support.type
+#           ^^ variable.parameter
+#             ^^ keyword.operator
+#               ^^^^ support.type
+#                     ^^ keyword.operator
+  (x, y) ->
+#  ^ variable.parameter
+#     ^ variable.parameter
+#        ^^ keyword.operator
+  (x::T{S}) ->
+#  ^ variable.parameter
+#   ^^ keyword.operator
+#     ^^^^ support.type
+#           ^^ keyword.operator
+  (x) ->
+#  ^ variable.parameter
+#     ^^ keyword.operator
+  x::T{S} ->
+# ^ variable.parameter
+#  ^^ keyword.operator
+#    ^^^^ support.type
+#         ^^ keyword.operator
+  x ->
+# ^ variable.parameter
+#   ^^ keyword.operator
+  ((x::Array{T}) where T<:Real{Foo}) -> 2x
+#   ^ variable.parameter
+#    ^^ keyword.operator
+#      ^^^^^^^^ support.type
+#                ^^^^^ keyword.other
+#                      ^ support.type
+#                       ^^ keyword.operator
+#                         ^^^^^^^^^ support.type
+#                                    ^^ keyword.operator
+  ((x::T{S}) -> 2x)
+#   ^ variable.parameter
+
+
+
+##
+## MACROS
+##
+
+  macro foo(a) end
+# ^^^^^ keyword.other
+#       ^^^ entity.name.macro
+#           ^ variable.parameter
+  @foo a
+# ^^^^ variable.macro
+#      ^ variable.other
+
+  @macro arg1 arg2
+# ^^^^^^ variable.macro
+#        ^^^^ variable.other
+#             ^^^^ variable.other
+  @macro(arg1,arg2)
+# ^^^^^^ variable.macro
+#        ^^^^ variable.other
+#             ^^^^ variable.other
+  @macro(arg1,arg2) = ...
+# ^^^^^^ variable.macro
+#        ^^^^ variable.other
+#             ^^^^ variable.other
+  function @macro(arg1,arg2) end
+# ^^^^^^^^ keyword.other
+#          ^^^^^^ variable.macro
+#                 ^^^^ variable.other
+#                      ^^^^ variable.other
+
+
+##
+## TRANSPOSES
+##
+
+# (issue 1, 15)
+  a'
+# ^ variable.other
+#  ^ keyword.operator
+  β.''
+# ^ variable.other
+#  ^ keyword.operator.broadcast
+#   ^^ keyword.operator
+  f()'
+# ^ variable.function
+#    ^ keyword.operator
+ (1.)'
+# ^^ constant.numeric
+#    ^ keyword.operator
+ [1,2]'
+# ^ constant.numeric
+#   ^ constant.numeric
+#     ^ keyword.operator
+
+
+##
+## INFIX OPERATORS
+##
+
+  a=b
+#  ^ keyword.operator.assignment
+  a >= b
+#   ^ keyword.operator.julia
+  a <= b
+#   ^ keyword.operator.julia
+  x -> 2 + x
+#   ^ keyword.operator
+  a => b
+#   ^ keyword.operator.julia
+  x .-= 3
+#   ^ keyword.operator.broadcast.julia
+#    ^ keyword.operator.julia
+  a == b
+#   ^ keyword.operator.julia
+  a != b
+#   ^ keyword.operator.julia
+  a === b
+#   ^ keyword.operator.julia
+#    ^ keyword.operator.julia
+#     ^ keyword.operator.julia
+  a !== b
+#   ^ keyword.operator.julia
+#    ^ keyword.operator.julia
+#     ^ keyword.operator.julia
+
+# (issue 6, 8, 10)
+  2.⊗a
+# ^^ constant.numeric
+#   ^ keyword.operator
+#    ^ variable.other
+  a⊕β()
+# ^ variable.other
+#  ^ keyword.operator
+#   ^ variable.function
+  1.23≤23.
+# ^^^^ constant.numeric
+#     ^ keyword.operator
+#      ^^^ constant.numeric
+
+
+##
+## BROADCAST
+##
+
+  f.(x)
+# ^ variable.function
+#  ^ keyword.operator.broadcast
+  Mod.f.(x)
+#     ^ variable.function
+#      ^ keyword.operator.broadcast
+  a.=b
+#  ^ keyword.operator.broadcast
+#   ^ keyword.operator.assignment
+  a.⊕b
+#  ^ keyword.operator.broadcast
+#   ^ keyword.operator
+
+
+##
+## COMMENTS
+##
+
+# (issue 13)
+  #fun()
+# ^^^^^^ comment.line
+# Nested block comments
+  #=#==#hej=#
+# ^^^^^^^^^^^ comment.block
+
+# (issue 27)
+  a#a
+# ^ variable.other
+#  ^^ comment.line
+  a#=a=# a
+# ^ variable.other
+#  ^^^^^ comment.block
+#        ^ variable.other
+
+
+##
+## STRINGS
+##
+
+"hello" closed
+# <- string.quoted.double
+# ^^^^^ string.quoted.double
+#         ^ variable.other
+'hello' closed
+# <- string.quoted.single
+# ^^^^^ string.quoted.single
+#       ^ variable.other
+  "hel\lo\"there"
+# ^^^^ string.quoted.double
+#     ^^ constant.character.escape
+#       ^ string.quoted.double
+#        ^^ constant.character.escape
+#          ^^^^^^ string.quoted.double
+# (issue 5)
+  r"\\\\" closed
+# ^^^^^^^ string.quoted.other
+#         ^ variable.other
+  r"raw\str\"ooh\\ok" closed
+# ^^^^^^^^^ string.quoted.other
+#          ^^ constant.character.escape
+#            ^^^ string.quoted.other
+#               ^^ constant.character.escape
+#                 ^^^ string.quoted.other
+#                     ^ variable.other
+  whatever"yaah" closed
+# ^^^^^^^^^^^^^^ string.quoted.other
+#                ^ variable.other
+  b"DATA\xffoho\u2200aha" closed
+# ^^^^^^ string.quoted.other
+#       ^^^^ constant.character.escape
+#           ^^^ string.quoted.other
+#              ^^^^^^ constant.character.escape
+#                    ^^^^ string.quoted.other
+#                         ^ variable.other
+# (issue 28)
+  r"""\n a \" b $""" a
+# ^^^^^^^^^ string.quoted.other
+#          ^^ constant.character.escape
+#            ^^^^^^^ string.quoted.other
+#                    ^ variable.other
+# (issue 29)
+  """a"$b"c"""
+# ^^^^^ string.quoted.double
+#      ^ keyword.operator
+#       ^ variable.other
+#        ^^^^^ string.quoted.double
+
+
+##
+## STRING INTERPOLATION
+##
+
+a = "f \$no $∇2() bar" closed
+#   ^^ string.quoted.double
+#      ^^ constant.character.escape
+#        ^^^ string.quoted.double
+#           ^ keyword.operator
+#            ^^ variable.other
+#              ^^^^^^^ string.quoted.double
+#                      ^ variable.other
+a = "foo$(a+f(a, g())+b)foobar" closed
+#   ^^^^ string.quoted.double
+#       ^ keyword.operator
+#         ^ variable.other
+#          ^ keyword.operator
+#           ^ variable.function
+#             ^ variable.other
+#                ^ variable.function
+#                     ^ variable.other
+#                       ^^^^^^^ string.quoted.double
+#                               ^ variable.other
+a = "foo$(a+f(a, g())+b)(a)bar" closed
+#   ^^^^ string.quoted.double
+#       ^ keyword.operator
+#         ^ variable.other
+#          ^ keyword.operator
+#           ^ variable.function
+#             ^ variable.other
+#                ^ variable.function
+#                     ^ variable.other
+#                       ^^^^^^^ string.quoted.double
+#                               ^ variable.other
+  a "f(x)=($(f(x)))" a
+# ^ variable.other
+#   ^^^^^^^ string.quoted.double
+#          ^ keyword.operator
+#            ^ variable.function
+#              ^ variable.other
+#                 ^^ string.quoted.double
+#                    ^ variable.other
+  "a $(f(a))$aa a" a
+# ^^^ string.quoted.double
+#    ^ keyword.operator
+#      ^ variable.function
+#           ^ keyword.operator
+#            ^^ variable.other
+#               ^^ string.quoted.double
+#                  ^ variable.other
+  f("$(g(a.b))") a
+#   ^ string
+#    ^ keyword
+#      ^ variable.function
+#             ^ string
+#                ^ variable.other
+  a = ? c-'0':b
+#       ^ variable.other
+#        ^ keyword.operator
+#         ^^^ string.quoted.single
+#            ^ keyword.operator
+#             ^ variable.other
+
+# (issue 25)
+  println("sqrt(4) = 2") closed
+# ^^^^^^^ variable.function
+#         ^^^^^^^^^^^^^ string.quoted
+#                        ^^^^^^ variable.other
+
+# (issue 32)
+  a `a$a` a
+# ^ variable.other
+#   ^^ string.quoted.cmd
+#     ^ keyword.operator
+#      ^ variable.other
+#       ^ string.quoted.cmd
+#         ^ variable.other

--- a/Julia.sublime-syntax
+++ b/Julia.sublime-syntax
@@ -1,1191 +1,632 @@
-# SYNTAX TEST "Packages/Julia/Julia.sublime-syntax"
-
-# For information on how this file is used, see
-# https://www.sublimetext.com/docs/3/syntax.html#testing
-# Run tests by pressing `ctrl+shift+b`, i.e. run the `build` command
-
-
-##
-## NUMBERS
-##
-
-  0b101
-# ^^^^^ constant.numeric
-  0o7
-# ^^^ constant.numeric
-  0xa3
-# ^^^^ constant.numeric
-  1e+123
-# ^^^^^^ constant.numeric
-  12e123
-# ^^^^^^ constant.numeric
-  1.32e+123
-# ^^^^^^^^^ constant.numeric
-  .32e+123
-# ^^^^^^^^ constant.numeric
-  1.e-123
-# ^^^^^^^ constant.numeric
-  11
-# ^^ constant.numeric
-  .11
-# ^^^ constant.numeric
-  11.
-# ^^^ constant.numeric
-  11.11
-# ^^^^^ constant.numeric
-  2.a
-# ^^ constant.numeric
-#   ^ variable.other
-# (issue 37)
-  123_4_56_7
-# ^^^^^^^^^^ constant.numeric
-  0xa_3_f
-# ^^^^^^^ constant.numeric
-  0b1_0_1
-# ^^^^^^^ constant.numeric
-  1.3_2e+1_2_3
-# ^^^^^^^^^^^^ constant.numeric
-# (issue 51)
-  e2
-# ^^ variable.other
-  2e
-# ^ constant.numeric
-#  ^ support.function
-  2e2
-# ^^^ constant.numeric
-  e+2
-# ^ support.function
-#  ^ keyword.operator
-#   ^ constant.numeric
-  2+e
-# ^ constant.numeric
-#  ^ keyword.operator
-#   ^ support.function
-
-
-##
-## CONSTANTS
-##
-
-  true
-# ^^^^ constant.language
-  false
-# ^^^^^ constant.language
-  nothing
-# ^^^^^^^ constant.language
-  NaN
-# ^^^ constant.language
-  Inf
-# ^^^ constant.language
-
-
-##
-## FUNCTION CALLS
-##
-
-# (issue 9, 16)
-  !β!(x)
-# ^ keyword.operator
-#  ^^ variable.function
-#     ^ variable.other
-  (x,f(x))
-#  ^ variable.other
-#    ^ variable.function
-#      ^ variable.other
-  √(2.3)
-# ^ variable.function
-#   ^^^ constant.numeric
-  TypeConstructor{Foo()}(a)
-# ^^^^^^^^^^^^^^^ variable.function
-#                ^^^^^^^ support.type
-#                        ^ variable.other
-
-# (issue 30)
-  f(a, ")=") a
-# ^ variable.function
-#   ^ variable.other
-#      ^^^^ string.quoted.double
-#            ^ variable.other
-  f(a, a=")=") = a
-# ^ entity.name.function
-#   ^ variable.parameter
-#      ^ variable.parameter
-#       ^ keyword.operator
-#        ^^^^ string.quoted.double
-#              ^ keyword.operator
-#                ^ variable.other
-  f(a, a=(")=")) = a
-# ^ entity.name.function
-#   ^ variable.parameter
-#      ^ variable.parameter
-#       ^ keyword.operator
-#         ^^^^ string.quoted.double
-#                ^ keyword.operator
-#                  ^ variable.other
-  f(a, a=")=\"a") = a
-# ^ entity.name.function
-#   ^ variable.parameter
-#      ^ variable.parameter
-#       ^ keyword.operator
-#        ^^^ string.quoted.double
-#           ^^ constant.character.escape
-#             ^^ string.quoted.double
-#                 ^ keyword.operator
-#                   ^ variable.other
-
-# (issue 46)
-  f(x)
-# ^^^^ meta.function-call
-# ^ variable.function
-#   ^  meta.function-call.arguments
-  abs(x)
-# ^^^ support.function
-# ^^^ variable.function
-  f(x=1)
-# ^ variable.function
-#   ^ variable.parameter
-#    ^ keyword.operator.assignment
-
-# (issue 47)
-  Base
-# ^^^^ support.module
-  Pkg.foo()
-# ^^^ support.module
-#     ^^^ variable.function
-  Core.foo(x) = 2
-# ^^^^ support.module
-  filter!()
-# ^^^^^^^ support.function
-  length
-# ^^^^^^ support.function
-  Base.filter!()
-# ^^^^ support.module
-#      ^^^^^^^ support.function
-  Base.filter!
-# ^^^^ support.module
-#      ^^^^^^^ support.function
-  Base.length
-# ^^^^ support.module
-#      ^^^^^^ support.function
-
-
-##
-## UNICODE WORD BOUDARIES
-##
-
-# Unicode and numbers in names (issue 18)
-  β1 = 5
-# ^^ variable.other
-  β3(x)
-# ^^ variable.function
-  β2(x) = x
-# ^^ entity.name.function
-  ∇1 = 5
-# ^^ variable.other
-  ∇3(x)
-# ^^ variable.function
-  ∇2(∇2) = x
-# ^^ entity.name.function
-#    ^^ variable.parameter
-
-# (issue 11)
-  a::B{C}=c()
-#  ^^ keyword.operator
-#    ^^^^ support.type
-#        ^ keyword.operator
-#         ^ variable.function
-
-
-##
-## SYMBOLS
-##
-
-  :a.b
-# ^ keyword.operator
-#  ^ constant.other.symbol
-#    ^ variable.other
-# (issue 3)
-  ,:βa
-#  ^ keyword.operator
-#   ^^ constant.other.symbol
-  [:+]
-#  ^ keyword.operator
-#   ^ constant.other.symbol
-  (:∘)
-#  ^ keyword.operator
-#   ^ constant.other.symbol
-  :a!
-# ^ keyword.operator
-#  ^^ constant.other.symbol
-  :(:)
-# ^ keyword.operator
-#  ^ source.julia
-#    ^ source.julia
-  :(a)
-# ^ keyword.operator
-#  ^ source.julia
-#   ^ variable.other
-#      ^ source.julia
-  :++a
-# ^ keyword.operator
-#  ^^ constant.other.symbol
-#    ^ variable.other
-  :+a
-# ^ keyword.operator
-#  ^ constant.other.symbol
-#   ^ variable.other
-  :∘+a # Yes, this is correct, equivalent to +(:∘, a)
-# ^ keyword.operator
-#  ^ constant.other.symbol
-#   ^ keyword.operator
-#    ^ variable.other
-  :.///a
-# ^ keyword.operator
-#  ^^^ constant.other.symbol
-#     ^ keyword.operator
-#      ^ variable.other
-# (issue 43)
-  :function
-# ^ keyword.operator
-#  ^^^^^^^^ constant.other.symbol
-
-:.a
-:.+a
-:.∘a
-:++a
-:+++a
-:/a
-://a
-:///a
-:.///a
-
-
-##
-## TERNARY OPERATORS
-##
-
-  a?b:c
-# ^ variable.other
-#  ^ keyword.operator
-#   ^ variable.other
-#    ^ keyword.operator
-#     ^ variable.other
-  a ? b :c
-# ^ variable.other
-#   ^ keyword.operator
-#     ^ variable.other
-#       ^ keyword.operator
-#        ^ variable.other
-
-
-##
-## RANGES
-##
-
-# (issue 14)
-  a:b
-# ^ variable.other
-#  ^ keyword.operator
-#   ^ variable.other
-  1.:a
-# ^^ constant.numeric
-#   ^ keyword.operator
-#    ^ variable.other
-  a:2.
-# ^ variable.other
-#  ^ keyword.operator
-#   ^^ constant.numeric
-  23.:31.
-# ^^^ constant.numeric
-#    ^ keyword.operator
-#     ^^^ constant.numeric
-  β:f()
-# ^ variable.other
-#  ^ keyword.operator
-#   ^ variable.function
-  f():1
-# ^ variable.function
-#    ^ keyword.operator
-#     ^ constant.numeric
-
-
-##
-## TYPES
-##
-
-  f(x::Foo, ::Bar{1, 2})
-# ^ variable.function
-#   ^ variable.other
-#    ^^ keyword.operator
-#      ^^^ support.type
-#           ^^ keyword.operator
-#             ^^^^^^^^^ support.type
-# Nested types
-  x::A{B,C{D,E},F{G,H{I,J{K,L{M}},N}}} closed
-#  ^^ keyword.operator
-#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.type
-# (issue 19)
-  myvar::MyModule.MyType
-# ^^^^^ variable.other
-#      ^^ keyword.operator
-#        ^^^^^^^^^^^^^^^ support.type
-
-# Modules (issue 19)
-  MyModule.myfunc(x)
-# ^^^^^^^^ variable.other
-#          ^^^^^^ variable.function
-#                 ^ variable.other
-
-# (issue 11)
-  aa::AA{BB} = fun{CC{DD}}()
-# ^^ variable.other
-#   ^^ keyword.operator
-#     ^^^^^^ support.type
-#            ^ keyword.operator
-#              ^^^ variable.function
-#                 ^^^^^^^^ support.type
-  aa::AA{BB}=fun{CC{DD}}() closed
-# ^^ variable.other
-#   ^^ keyword.operator
-#     ^^^^^^ support.type
-#           ^ keyword.operator
-#            ^^^ variable.function
-#               ^^^^^^^^ support.type
-#                          ^^^^^^ variable.other
-  mytype = Array
-# ^^^^^^ variable.other
-#        ^ keyword.operator
-#          ^^^^^ support.type
-  mytype = Array{Int}
-# ^^^^^^ variable.other
-#        ^ keyword.operator
-#          ^^^^^^^^^^ support.type
-  mytype = CallMsg{:call}
-#          ^^^^^^^^^^^^^^ support.type
-
-# Julia 0.6 (issue 45)
-  A = Array{T} where T<:Integer{Foo}
-#     ^^^^^^^^ support.type
-#              ^^^^^ keyword.other
-#                    ^ support.type
-#                     ^^ keyword.operator
-#                       ^^^^^^^^^^^^ support.type
-  S >: T
-# ^ support.type
-#   ^^ keyword.operator
-#      ^ support.type
-  Foo <: $A{$A}
-# ^^^ support.type
-#     ^^ keyword.operator
-#        ^^^^^^ support.type
-  $A{$A} >: $A{$A}
-# ^^^^^^ support.type
-#        ^^ keyword.operator
-#           ^^^^^^ support.type
-
-# (issue 17)
-# All things being defined are green, types as well
-  type Foo{T<:Real} end
-# ^^^^ keyword.other
-#      ^^^ entity.name.type
-#         ^^^^^^^^^ support.type
-  type A <: B end
-# ^^^^ keyword.other
-#      ^ entity.name.type
-#        ^^ keyword.operator
-#           ^ support.type
-#             ^^^ keyword.other
-  type Foo{T}<:Bar{T} end
-# ^^^^ keyword.other
-#      ^^^ entity.name.type
-#         ^^^ support.type
-#            ^^ keyword.operator
-#              ^^^^^^ support.type
-  immutable Foo{T<:Real} end
-# ^^^^^^^^^ keyword.other
-#           ^^^ entity.name.type
-#              ^^^^^^^^^ support.type
-  typealias Foo{T} Bar{T}
-# ^^^^^^^^^ keyword.other
-#           ^^^^^^ entity.name.type
-#                  ^^^^^^ support.type
-  bitstype 32 Foo{T}<:Bar{T}
-# ^^^^^^^^ keyword.other
-#          ^^ constant.numeric
-#             ^^^^^^ entity.name.type
-#                   ^^ keyword.operator
-#                     ^^^^^^ support.type
-
-# Julia 0.6 (issue 45)
-  struct Foo{T} end
-# ^^^^^^ keyword.other
-#        ^^^ entity.name.type
-#           ^^^ support.type
-#               ^^^ keyword.other
-  mutable struct Foo{T} end
-# ^^^^^^^ keyword.other
-#         ^^^^^^ keyword.other
-#                ^^^ entity.name.type
-#                   ^^^ support.type
-#                       ^^^ keyword.other
-  abstract type Foo{T} end
-# ^^^^^^^^ keyword.other
-#          ^^^^ keyword.other
-#               ^^^ entity.name.type
-#                  ^^^ support.type
-#                      ^^^ keyword.other
-  primitive type Char 32 end
-# ^^^^^^^^^ keyword.other
-#           ^^^^ keyword.other
-#                ^^^^ entity.name.type
-#                     ^^ constant.numeric
-#                        ^^^ keyword.other
-
-# (issue 52)
-  mutable struct $Foo{T} end
-# ^^^^^^^ keyword.other
-#         ^^^^^^ keyword.other
-#                ^^^^ entity.name.type
-#                    ^^^ support.type
-#                        ^^^ keyword.other
-
-
-##
-## FUNCTION DEFINITIONS
-##
-
-  function f(a::b) end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^ keyword.operator
-#               ^ support.type
-#                  ^^^ keyword.other
-
-  function Module.foo!{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) end
-# ^^^^^^^^ keyword.other
-#          ^^^^^^ variable.other
-#                ^ keyword.operator
-#                 ^^^^ entity.name.function
-#                     ^^^^^^^^^ support.type
-#                               ^^ variable.parameter
-#                                 ^^ keyword.operator
-#                                   ^^^^^^ support.type
-#                                           ^ variable.parameter
-#                                            ^^ keyword.operator
-#                                              ^^^^^^ support.type
-#                                                    ^ keyword.operator
-#                                                     ^^ constant.numeric
-#                                                       ^^ keyword.operator
-#                                                         ^^^^^^ support.type
-#                                                                 ^ variable.parameter
-#                                                                    ^^^ keyword.other
-
-# Infix operator declaration
-  function ∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#           ^^^^^^^^^ support.type
-#                     ^^ variable.parameter
-#                       ^^ keyword.operator
-#                         ^^^^^^ support.type
-#                                 ^ variable.parameter
-#                                  ^^ keyword.operator
-#                                    ^^^^^^ support.type
-#                                          ^ keyword.operator
-#                                           ^^ constant.numeric
-#                                             ^^ keyword.operator
-#                                               ^^^^^^ support.type
-#                                                       ^ variable.parameter
-#                                                          ^^^ keyword.other
-
-# Infix operator declaration in module
-  function Module.∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) end
-# ^^^^^^^^ keyword.other
-#          ^^^^^^ variable.other
-#                ^ keyword.operator
-#                 ^ entity.name.function
-#                  ^^^^^^^^^ support.type
-#                            ^^ variable.parameter
-#                              ^^ keyword.operator
-#                                ^^^^^^ support.type
-#                                        ^ variable.parameter
-#                                         ^^ keyword.operator
-#                                           ^^^^^^ support.type
-#                                                 ^ keyword.operator
-#                                                  ^^ constant.numeric
-#                                                    ^^ keyword.operator
-#                                                      ^^^^^^ support..type
-#                                                              ^ variable.parameter
-#                                                                 ^^^ keyword.other
-
-# Assignemetn-form function declaration (issue 19)
-  MyModule.foo!{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) = kron(a, b)
-# ^^^^^^^^ variable.other
-#          ^^^^ entity.name.function
-#              ^^^^^^^^^ support.type
-#                        ^^ variable.parameter
-#                          ^^ keyword.operator
-#                            ^^^^^^ support.type
-#                                    ^ variable.parameter
-#                                     ^^ keyword.operator
-#                                       ^^^^^^ support.type
-#                                             ^ keyword.operator
-#                                              ^^ constant.numeric
-#                                                ^^ keyword.operator
-#                                                  ^^^^^^ support.type
-#                                                          ^ variable.parameter
-#                                                             ^ keyword.operator
-
-# Assignemetn-form infix operator declaration
-  ∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) = ...
-# ^ entity.name.function
-#  ^^^^^^^^^ support.type
-#            ^^ variable.parameter
-#              ^^ keyword.operator
-#                ^^^^^^ support.type
-#                        ^ variable.parameter
-#                         ^^ keyword.operator
-#                           ^^^^^^ support.type
-#                                 ^ keyword.operator
-#                                  ^^ constant.numeric
-#                                    ^^ keyword.operator
-#                                      ^^^^^^ support.type
-#                                              ^ variable.parameter
-#                                                 ^ keyword.operator
-
-# Assignemetn-form infix operator declaration in module
-  MyModule.∘{T<:Real}(xx::Aa{Bb}, β::Aa{Bb}=1.::Aa{Bb}, c) = ...
-# ^^^^^^^^ variable.other
-#          ^ entity.name.function
-#           ^^^^^^^^^  support.type
-#                     ^^ variable.parameter
-#                       ^^ keyword.operator
-#                         ^^^^^^  support.type
-#                                 ^ variable.parameter
-#                                  ^^ keyword.operator
-#                                    ^^^^^^  support.type
-#                                          ^ keyword.operator
-#                                           ^^ constant.numeric
-#                                             ^^ keyword.operator
-#                                               ^^^^^^ support.type
-#                                                       ^ variable.parameter
-#                                                          ^ keyword.operator
-
-# (issue 23)
-  f(a::B{()}) = ...
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^^ keyword.operator
-#      ^^^^^ support.type
-#             ^ keyword.operator
-
-# Splats and interpolated types
-  f(x..., x::$Foo..., a=a) = ...
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^^^ keyword.operator
-#         ^ variable.parameter
-#          ^^ keyword.operator
-#            ^^^^ support.type
-#                ^^^ keyword.operator
-#                     ^ variable.parameter
-#                      ^ keyword.operator
-#                       ^ variable.other
-  function f(x..., x::$Foo{$T}..., a=a) end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^^ keyword.operator
-#                  ^ variable.parameter
-#                   ^^ keyword.operator
-#                     ^^^^^^^^ support.type
-#                             ^^^ keyword.operator
-#                                  ^ variable.parameter
-#                                   ^ keyword.operator
-#                                    ^ variable.other
-#                                       ^^^ keyword.other
-
-# Parenthesized function name
-  function (a)(b) end
-# ^^^^^^^^ keyword.other
-#           ^ entity.name.function
-#              ^ variable.parameter
-#                 ^^^ keyword.other
-  function (+)(a) end
-# ^^^^^^^^ keyword.other
-#           ^ entity.name.function
-#              ^ variable.parameter
-#                 ^^^ keyword.other
-  (+)(a, b) = ...
-#  ^ entity.name.function
-#     ^ variable.parameter
-#        ^ variable.parameter
-#           ^ keyword.operator
-
-# Anonymous function
-  function (a) foo end
-# ^^^^^^^^ keyword.other
-#           ^ variable.parameter
-#              ^^^ variable.other
-#                  ^^^ keyword.other
-
-# Type constructor
- (::Type{Foo{A}}){B}(a::Bar{B}) = ...
-# ^^ keyword.operator
-#   ^^^^^^^^^^^^ entity.name.function
-#                ^^^ support.type
-#                    ^ variable.parameter
-#                     ^^ keyword.operator
-#                       ^^^^^^ support.type
-  function (::Type{Foo{A}}){B}(a::Bar{b})
-# ^^^^^^^^ keyword.other
-#           ^^ keyword.operator
-#             ^^^^^^^^^^^^ entity.name.function
-#                          ^^^ support.type
-#                              ^ variable.parameter
-#                               ^^ keyword.operator
-#                                 ^^^^^^ support.type
-  f(a="()") = a
-# ^ entity.name.function
-#   ^ variable.parameter
-#     ^^^^ string.quoted
-#           ^ keyword.operator
-#             ^ variable.other
-
-  (::f{A()}){A{B()}}(a) = ...
-#  ^^ keyword.operator
-#    ^^^^^^ entity.name.function
-#           ^^^^^^^^ support.type
-#                    ^ variable.parameter
-
-  f(a=[b,c]) = d
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^ keyword.operator
-#      ^ variable.other
-#        ^ variable.other
-#            ^ keyword.operator
-#              ^ variable.other
-
-# (issue 31)
-  f(x::A=5; z) = ...
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^^ keyword.operator
-#      ^ support.type
-#       ^ keyword.operator
-#        ^ constant.numeric
-#           ^ variable.parameter
-
-# (issue 33)
-  f(::Int, x::Float64) = x
-# ^ entity.name.function
-#   ^^ keyword.operator
-#     ^^^ support.type
-#          ^variable.parameter
-#           ^^ keyword.operator
-#             ^^^^^^^ support.type
-
-  f(; x::Float64) = x
-# ^ entity.name.function
-#     ^ variable.parameter
-#      ^^ keyword.operator
-#        ^^^^^^^ support.type
-
-# The following fails, function parameters should be highlighted.
-# There seems to be no way of solving this, see issue #33.
-  f(x,
-    y) = ...
-# Tests are removed, to avoid superfluous test fails (comments are ignored).
-
-# (issue 40)
-  function foo end
-# ^^^^^^^^ keyword.other
-#          ^^^ entity.name.function
-#              ^^^ keyword.other
-  function foo (x) end
-# ^^^^^^^^ keyword.other
-#          ^^^ entity.name.function
-#               ^ variable.parameter
-#                  ^^^ keyword.other
-
-# Jula 0.6 (issue 45)
-  function inv(M::Matrix{T}) where T<:AbstractFloat end
-# ^^^^^^^^ keyword.other
-#          ^^^ entity.name.function
-#              ^ variable.parameter
-#               ^^ keyword.operator
-#                 ^^^^^^^^^ support.type
-#                            ^^^^^ keyword.other
-#                                  ^  support.type
-#                                   ^^ keyword.operator
-#                                     ^^^^^^^^^^^^^ support.type
-#                                                   ^^^ keyword.other
-  function inv(M::Matrix{T} where T<:AbstractFloat) end
-# ^^^^^^^^ keyword.other
-#          ^^^ entity.name.function
-#              ^ variable.parameter
-#               ^^ keyword.operator
-#                 ^^^^^^^^^ support.type
-#                           ^^^^^ keyword.other
-#                                 ^  support.type
-#                                  ^^ keyword.operator
-#                                    ^^^^^^^^^^^^^ support.type
-#                                                   ^^^ keyword.other
-  inv(M::Matrix{T}) where T<:AbstractFloat = M
-# ^^^ entity.name.function
-#     ^ variable.parameter
-#      ^^ keyword.operator
-#        ^^^^^^^^^ support.type
-#                   ^^^^^ keyword.other
-#                         ^  support.type
-#                          ^^ keyword.operator
-#                            ^^^^^^^^^^^^^ support.type
-#                                          ^ keyword.operator
-  inv(M::Matrix{T}) where {T<:AbstractFloat} = M
-# ^^^ entity.name.function
-#     ^ variable.parameter
-#      ^^ keyword.operator
-#        ^^^^^^^^^ support.type
-#                   ^^^^^ keyword.other
-#                         ^^  support.type
-#                           ^^ keyword.operator
-#                             ^^^^^^^^^^^^^^ support.type
-#                                            ^ keyword.operator
-  inv(M::Matrix{T} where T<:AbstractFloat) = M
-# ^^^ entity.name.function
-#     ^ variable.parameter
-#      ^^ keyword.operator
-#        ^^^^^^^^^ support.type
-#                  ^^^^^ keyword.other
-#                        ^  support.type
-#                         ^^ keyword.operator
-#                           ^^^^^^^^^^^^^ support.type
-#                                          ^ keyword.operator
-  inv(M::Matrix{T} where {T<:AbstractFloat}) = M
-# ^^^ entity.name.function
-#     ^ variable.parameter
-#      ^^ keyword.operator
-#        ^^^^^^^^^ support.type
-#                  ^^^^^ keyword.other
-#                        ^^  support.type
-#                          ^^ keyword.operator
-#                            ^^^^^^^^^^^^^^ support.type
-#                                            ^ keyword.operator
-  f(x::Array{T,S} where T) = x
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^^ keyword.operator
-#      ^^^^^^^^^^ support.type
-#                 ^^^^^ keyword.other
-#                       ^ support.type
-#                          ^ keyword.operator
-  f(x::Array{T,S} where T where S) = x
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^^ keyword.operator
-#      ^^^^^^^^^^ support.type
-#                 ^^^^^ keyword.other
-#                       ^ support.type
-#                         ^^^^^ keyword.other
-#                               ^ support.type
-#                                  ^ keyword.operator
-  f(x::Array{T,S}) where T = x
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^^ keyword.operator
-#      ^^^^^^^^^^ support.type
-#                  ^^^^^ keyword.other
-#                        ^ support.type
-#                          ^ keyword.operator
-  f(x::Array{T,S}) where T where S = x
-# ^ entity.name.function
-#   ^ variable.parameter
-#    ^^ keyword.operator
-#      ^^^^^^^^^^ support.type
-#                  ^^^^^ keyword.other
-#                        ^ support.type
-#                          ^^^^^ keyword.other
-#                                ^ support.type
-#                                  ^ keyword.operator
-  function f(x::Array{T,S}) where T end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^ keyword.operator
-#               ^^^^^^^^^^ support.type
-#                           ^^^^^ keyword.other
-#                                 ^ support.type
-#                                   ^^^ keyword.other
-  function f(x::Array{T,S}) where T where S end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^ keyword.operator
-#               ^^^^^^^^^^ support.type
-#                           ^^^^^ keyword.other
-#                                 ^ support.type
-#                                   ^^^^^ keyword.other
-#                                         ^ support.type
-#                                           ^^^ keyword.other
-  function f(x::Array{T,S} where T) end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^ keyword.operator
-#               ^^^^^^^^^^ support.type
-#                          ^^^^^ keyword.other
-#                                ^ support.type
-#                                   ^^^ keyword.other
-  function f(x::Array{T,S} where T where S) end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^ keyword.operator
-#               ^^^^^^^^^^ support.type
-#                          ^^^^^ keyword.other
-#                                ^ support.type
-#                                  ^^^^^ keyword.other
-#                                        ^ support.type
-#                                           ^^^ keyword.other
-  function f(x::typeof(yy) where T where S) end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^ keyword.operator
-#               ^^^^^^^^^^ support.type
-#                          ^^^^^ keyword.other
-#                                ^ support.type
-#                                  ^^^^^ keyword.other
-#                                        ^ support.type
-#                                           ^^^ keyword.other
-  function *(x::Bool, y::T)::promote_type(Bool,T) where T<:Unsigned end
-# ^^^^^^^^ keyword.other
-#          ^ entity.name.function
-#            ^ variable.parameter
-#             ^^ keyword.operator
-#               ^^^^ support.type
-#                     ^ variable.parameter
-#                      ^^ keyword.operator
-#                        ^ support.type
-#                          ^^ keyword.operator
-#                            ^^^^^^^^^^^^^^^^^^^^ support.type
-#                                                 ^^^^^ keyword.other
-#                                                       ^ support.type
-#                                                        ^^ keyword.operator
-#                                                          ^^^^^^^^ support.type
-#                                                                   ^^^ keyword.other
-
-# Anonymous functions
-  (x::T{S}, yy::T{S}) ->
-#  ^ variable.parameter
-#   ^^ keyword.operator
-#     ^^^^ support.type
-#           ^^ variable.parameter
-#             ^^ keyword.operator
-#               ^^^^ support.type
-#                     ^^ keyword.operator
-  (x, y) ->
-#  ^ variable.parameter
-#     ^ variable.parameter
-#        ^^ keyword.operator
-  (x::T{S}) ->
-#  ^ variable.parameter
-#   ^^ keyword.operator
-#     ^^^^ support.type
-#           ^^ keyword.operator
-  (x) ->
-#  ^ variable.parameter
-#     ^^ keyword.operator
-  x::T{S} ->
-# ^ variable.parameter
-#  ^^ keyword.operator
-#    ^^^^ support.type
-#         ^^ keyword.operator
-  x ->
-# ^ variable.parameter
-#   ^^ keyword.operator
-  ((x::Array{T}) where T<:Real{Foo}) -> 2x
-#   ^ variable.parameter
-#    ^^ keyword.operator
-#      ^^^^^^^^ support.type
-#                ^^^^^ keyword.other
-#                      ^ support.type
-#                       ^^ keyword.operator
-#                         ^^^^^^^^^ support.type
-#                                    ^^ keyword.operator
-  ((x::T{S}) -> 2x)
-#   ^ variable.parameter
-
-
-
-##
-## MACROS
-##
-
-  macro foo(a) end
-# ^^^^^ keyword.other
-#       ^^^ entity.name.macro
-#           ^ variable.parameter
-  @foo a
-# ^^^^ variable.macro
-#      ^ variable.other
-
-  @macro arg1 arg2
-# ^^^^^^ variable.macro
-#        ^^^^ variable.other
-#             ^^^^ variable.other
-  @macro(arg1,arg2)
-# ^^^^^^ variable.macro
-#        ^^^^ variable.other
-#             ^^^^ variable.other
-  @macro(arg1,arg2) = ...
-# ^^^^^^ variable.macro
-#        ^^^^ variable.other
-#             ^^^^ variable.other
-  function @macro(arg1,arg2) end
-# ^^^^^^^^ keyword.other
-#          ^^^^^^ variable.macro
-#                 ^^^^ variable.other
-#                      ^^^^ variable.other
-
-
-##
-## TRANSPOSES
-##
-
-# (issue 1, 15)
-  a'
-# ^ variable.other
-#  ^ keyword.operator
-  β.''
-# ^ variable.other
-#  ^ keyword.operator.broadcast
-#   ^^ keyword.operator
-  f()'
-# ^ variable.function
-#    ^ keyword.operator
- (1.)'
-# ^^ constant.numeric
-#    ^ keyword.operator
- [1,2]'
-# ^ constant.numeric
-#   ^ constant.numeric
-#     ^ keyword.operator
-
-
-##
-## INFIX OPERATORS
-##
-
-  a=b
-#  ^ keyword.operator.assignment
-  a >= b
-#   ^ keyword.operator.julia
-  a <= b
-#   ^ keyword.operator.julia
-  x -> 2 + x
-#   ^ keyword.operator
-  a => b
-#   ^ keyword.operator.julia
-  x .-= 3
-#   ^ keyword.operator.broadcast.julia
-#    ^ keyword.operator.julia
-  a == b
-#   ^ keyword.operator.julia
-  a != b
-#   ^ keyword.operator.julia
-  a === b
-#   ^ keyword.operator.julia
-#    ^ keyword.operator.julia
-#     ^ keyword.operator.julia
-  a !== b
-#   ^ keyword.operator.julia
-#    ^ keyword.operator.julia
-#     ^ keyword.operator.julia
-
-# (issue 6, 8, 10)
-  2.⊗a
-# ^^ constant.numeric
-#   ^ keyword.operator
-#    ^ variable.other
-  a⊕β()
-# ^ variable.other
-#  ^ keyword.operator
-#   ^ variable.function
-  1.23≤23.
-# ^^^^ constant.numeric
-#     ^ keyword.operator
-#      ^^^ constant.numeric
-
-
-##
-## BROADCAST
-##
-
-  f.(x)
-# ^ variable.function
-#  ^ keyword.operator.broadcast
-  Mod.f.(x)
-#     ^ variable.function
-#      ^ keyword.operator.broadcast
-  a.=b
-#  ^ keyword.operator.broadcast
-#   ^ keyword.operator.assignment
-  a.⊕b
-#  ^ keyword.operator.broadcast
-#   ^ keyword.operator
-
-
-##
-## COMMENTS
-##
-
-# (issue 13)
-  #fun()
-# ^^^^^^ comment.line
-# Nested block comments
-  #=#==#hej=#
-# ^^^^^^^^^^^ comment.block
-
-# (issue 27)
-  a#a
-# ^ variable.other
-#  ^^ comment.line
-  a#=a=# a
-# ^ variable.other
-#  ^^^^^ comment.block
-#        ^ variable.other
-
-
-##
-## STRINGS
-##
-
-"hello" closed
-# <- string.quoted.double
-# ^^^^^ string.quoted.double
-#         ^ variable.other
-'hello' closed
-# <- string.quoted.single
-# ^^^^^ string.quoted.single
-#       ^ variable.other
-  "hel\lo\"there"
-# ^^^^ string.quoted.double
-#     ^^ constant.character.escape
-#       ^ string.quoted.double
-#        ^^ constant.character.escape
-#          ^^^^^^ string.quoted.double
-# (issue 5)
-  r"\\\\" closed
-# ^^^^^^^ string.quoted.other
-#         ^ variable.other
-  r"raw\str\"ooh\\ok" closed
-# ^^^^^^^^^ string.quoted.other
-#          ^^ constant.character.escape
-#            ^^^ string.quoted.other
-#               ^^ constant.character.escape
-#                 ^^^ string.quoted.other
-#                     ^ variable.other
-  whatever"yaah" closed
-# ^^^^^^^^^^^^^^ string.quoted.other
-#                ^ variable.other
-  b"DATA\xffoho\u2200aha" closed
-# ^^^^^^ string.quoted.other
-#       ^^^^ constant.character.escape
-#           ^^^ string.quoted.other
-#              ^^^^^^ constant.character.escape
-#                    ^^^^ string.quoted.other
-#                         ^ variable.other
-# (issue 28)
-  r"""\n a \" b $""" a
-# ^^^^^^^^^ string.quoted.other
-#          ^^ constant.character.escape
-#            ^^^^^^^ string.quoted.other
-#                    ^ variable.other
-# (issue 29)
-  """a"$b"c"""
-# ^^^^^ string.quoted.double
-#      ^ keyword.operator
-#       ^ variable.other
-#        ^^^^^ string.quoted.double
-
-
-##
-## STRING INTERPOLATION
-##
-
-a = "f \$no $∇2() bar" closed
-#   ^^ string.quoted.double
-#      ^^ constant.character.escape
-#        ^^^ string.quoted.double
-#           ^ keyword.operator
-#            ^^ variable.other
-#              ^^^^^^^ string.quoted.double
-#                      ^ variable.other
-a = "foo$(a+f(a, g())+b)foobar" closed
-#   ^^^^ string.quoted.double
-#       ^ keyword.operator
-#         ^ variable.other
-#          ^ keyword.operator
-#           ^ variable.function
-#             ^ variable.other
-#                ^ variable.function
-#                     ^ variable.other
-#                       ^^^^^^^ string.quoted.double
-#                               ^ variable.other
-a = "foo$(a+f(a, g())+b)(a)bar" closed
-#   ^^^^ string.quoted.double
-#       ^ keyword.operator
-#         ^ variable.other
-#          ^ keyword.operator
-#           ^ variable.function
-#             ^ variable.other
-#                ^ variable.function
-#                     ^ variable.other
-#                       ^^^^^^^ string.quoted.double
-#                               ^ variable.other
-  a "f(x)=($(f(x)))" a
-# ^ variable.other
-#   ^^^^^^^ string.quoted.double
-#          ^ keyword.operator
-#            ^ variable.function
-#              ^ variable.other
-#                 ^^ string.quoted.double
-#                    ^ variable.other
-  "a $(f(a))$aa a" a
-# ^^^ string.quoted.double
-#    ^ keyword.operator
-#      ^ variable.function
-#           ^ keyword.operator
-#            ^^ variable.other
-#               ^^ string.quoted.double
-#                  ^ variable.other
-  f("$(g(a.b))") a
-#   ^ string
-#    ^ keyword
-#      ^ variable.function
-#             ^ string
-#                ^ variable.other
-  a = ? c-'0':b
-#       ^ variable.other
-#        ^ keyword.operator
-#         ^^^ string.quoted.single
-#            ^ keyword.operator
-#             ^ variable.other
-
-# (issue 25)
-  println("sqrt(4) = 2") closed
-# ^^^^^^^ variable.function
-#         ^^^^^^^^^^^^^ string.quoted
-#                        ^^^^^^ variable.other
-
-# (issue 32)
-  a `a$a` a
-# ^ variable.other
-#   ^^ string.quoted.cmd
-#     ^ keyword.operator
-#      ^ variable.other
-#       ^ string.quoted.cmd
-#         ^ variable.other
+%YAML 1.2
+---
+
+# https://www.sublimetext.com/docs/3/syntax.html
+# https://www.sublimetext.com/docs/3/scope_naming.html
+
+
+# Julia is a language under development, this syntax strives to
+# support the latest version of Julia.
+# Julia is currently transitioning from version 0.5 to 0.6,
+# the changes in 0.6 are listed here https://github.com/JuliaLang/julia/blob/master/NEWS.md
+# Some syntax is being removed, but kept for now as deprecated, such
+# features are marked with "# DEPRECATED 0.6" in this file.
+
+# TODO: When 0.6 is properly released, re-run all generated regexes, ones commented with "# julia> ...".
+# The current 0.6 alpha had some issues...
+
+
+name: Julia
+file_extensions: [jl]
+first_line_match: ^#!.*\bjulia\s*$
+scope: source.julia
+
+variables:
+  symb_op_ascii: '[-+*/\\=^:<>~?&$%|]'
+
+  # The list of unicode symbols allowed as operators is fetched from the Julia parser https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm
+  symb_op_unicode: '[≤≥¬←→↔↚↛↠↣↦↮⇎⇏⇒⇔⇴⇶⇷⇸⇹⇺⇻⇼⇽⇾⇿⟵⟶⟷⟷⟹⟺⟻⟼⟽⟾⟿⤀⤁⤂⤃⤄⤅⤆⤇⤌⤍⤎⤏⤐⤑⤔⤕⤖⤗⤘⤝⤞⤟⤠⥄⥅⥆⥇⥈⥊⥋⥎⥐⥒⥓⥖⥗⥚⥛⥞⥟⥢⥤⥦⥧⥨⥩⥪⥫⥬⥭⥰⧴⬱⬰⬲⬳⬴⬵⬶⬷⬸⬹⬺⬻⬼⬽⬾⬿⭀⭁⭂⭃⭄⭇⭈⭉⭊⭋⭌￩￫≡≠≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≔≕≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩴⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⊕⊖⊞⊟∪∨⊔±∓∔∸≂≏⊎⊻⊽⋎⋓⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣÷⋅∘×∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗↑↓⇵⟰⟱⤈⤉⤊⤋⤒⤓⥉⥌⥍⥏⥑⥔⥕⥘⥙⥜⥝⥠⥡⥣⥥⥮⥯￪￬]'
+  symb_op: '(?:{{symb_op_ascii}}|{{symb_op_unicode}})'
+
+  # Multi-character operators
+  long_op: (?:\+=|-=|\*=|/=|//=|\\\\=|^=|÷=|%=|<<=|>>=|>>>=|\|=|&=|:=|=>|$=|\|\||&&|<:|>:|\|>|<\||//|\+\+|<=|>=|->|===|==|!==|!=)
+
+  # julia> join(sort(unique((filter(x -> isalpha(x[1]), string.(filter!(x -> isa(eval(x), DataType) || isa(eval(x), TypeConstructor), [names(Base); names(Core)])))))), "|")
+  # Julia 0.6 seems to uses UnionAll instead of TypeConstructor
+  # Compare with https://github.com/JuliaLang/julia/blob/master/base/exports.jl
+  base_types: \b(?:AbstractArray|AbstractChannel|AbstractFloat|AbstractMatrix|AbstractRNG|AbstractSerializer|AbstractSparseArray|AbstractSparseMatrix|AbstractSparseVector|AbstractString|AbstractUnitRange|AbstractVecOrMat|AbstractVector|Any|ArgumentError|Array|AssertionError|Associative|Base64DecodePipe|Base64EncodePipe|Bidiagonal|BigFloat|BigInt|BitArray|BitMatrix|BitVector|Bool|BoundsError|BufferStream|CachingPool|CapturedException|CartesianIndex|CartesianRange|Cchar|Cdouble|Cfloat|Channel|Char|Cint|Cintmax_t|Clong|Clonglong|ClusterManager|Cmd|Colon|Complex|Complex128|Complex32|Complex64|CompositeException|Condition|Cptrdiff_t|Cshort|Csize_t|Cssize_t|Cstring|Cuchar|Cuint|Cuintmax_t|Culong|Culonglong|Cushort|Cwchar_t|Cwstring|DataType|Date|DateTime|DenseArray|DenseMatrix|DenseVecOrMat|DenseVector|Diagonal|Dict|DimensionMismatch|Dims|DirectIndexString|Display|DivideError|DomainError|EOFError|EachLine|Enum|Enumerate|ErrorException|Exception|Expr|Factorization|FileMonitor|Filter|Float16|Float32|Float64|FloatRange|Function|Future|GlobalRef|GotoNode|HTML|Hermitian|IO|IOBuffer|IOContext|IOStream|IPAddr|IPv4|IPv6|InexactError|InitError|Int|Int128|Int16|Int32|Int64|Int8|IntSet|Integer|InterruptException|InvalidStateException|Irrational|KeyError|LabelNode|LambdaInfo|LinSpace|LineNumberNode|LoadError|LowerTriangular|MIME|Matrix|MersenneTwister|Method|MethodError|MethodTable|Module|NTuple|NewvarNode|NullException|Nullable|Number|ObjectIdDict|OrdinalRange|OutOfMemoryError|OverflowError|Pair|ParseError|PartialQuickSort|Pipe|PollingFileWatcher|ProcessExitedException|Ptr|QuoteNode|RandomDevice|Range|Rational|RawFD|ReadOnlyMemoryError|Real|ReentrantLock|Ref|Regex|RegexMatch|RemoteChannel|RemoteException|RepString|RevString|RoundingMode|SSAValue|SegmentationFault|SerializationState|Set|SharedArray|SharedMatrix|SharedVector|Signed|SimpleVector|Slot|SlotNumber|SparseMatrixCSC|SparseVector|StackFrame|StackOverflowError|StackTrace|StepRange|StridedArray|StridedMatrix|StridedVecOrMat|StridedVector|String|SubArray|SubString|SymTridiagonal|Symbol|Symmetric|SystemError|TCPSocket|Task|Text|TextDisplay|Timer|Tridiagonal|Tuple|Type|TypeConstructor|TypeError|TypeMapEntry|TypeMapLevel|TypeName|TypeVar|TypedSlot|UDPSocket|UInt|UInt128|UInt16|UInt32|UInt64|UInt8|UndefRefError|UndefVarError|UnicodeError|UniformScaling|Union|UnitRange|Unsigned|UpperTriangular|Val|Vararg|VecElement|VecOrMat|Vector|VersionNumber|Void|WeakKeyDict|WeakRef|WorkerConfig|WorkerPool|Zip)\b
+
+  # julia> join(filter!(x -> isascii(x[1]) && isalpha(x[1]) && islower(x[1]), map(string, [names(Base); names(Core)])), '|')
+  base_funcs: (?:abs|abs2|abspath|accept|acos|acosd|acosh|acot|acotd|acoth|acsc|acscd|acsch|addprocs|airy|airyai|airyaiprime|airybi|airybiprime|airyprime|airyx|all|all!|allunique|angle|any|any!|append!|apropos|ascii|asec|asecd|asech|asin|asind|asinh|assert|asyncmap|atan|atan2|atand|atanh|atexit|atreplinit|backtrace|base|base64decode|base64encode|basename|besselh|besselhx|besseli|besselix|besselj|besselj0|besselj1|besseljx|besselk|besselkx|bessely|bessely0|bessely1|besselyx|beta|bfft|bfft!|big|bin|bind|binomial|bitbroadcast|bitpack|bitrand|bits|bitunpack|bkfact|bkfact!|blas_set_num_threads|blkdiag|brfft|broadcast|broadcast!|broadcast!_function|broadcast_function|broadcast_getindex|broadcast_setindex!|bswap|bytes2hex|bytestring|call|cat|catalan|catch_backtrace|catch_stacktrace|cbrt|cd|ceil|cell|cfunction|cglobal|charwidth|checkbounds|checkindex|chmod|chol|cholfact|cholfact!|chomp|chop|chown|chr2ind|circshift|cis|clamp|clamp!|cld|clear!|clipboard|close|cmp|code_llvm|code_lowered|code_native|code_typed|code_warntype|collect|colon|combinations|complex|cond|condskeel|conj|conj!|connect|consume|contains|conv|conv2|convert|copy|copy!|copysign|cor|cos|cosc|cosd|cosh|cospi|cot|cotd|coth|count|count_ones|count_zeros|countfrom|countlines|countnz|cov|cp|cross|csc|cscd|csch|ctime|ctranspose|ctranspose!|cummax|cummin|cumprod|cumprod!|cumsum|cumsum!|cumsum_kbn|current_module|current_task|cycle|dawson|dct|dct!|dec|deconv|deepcopy|default_worker_pool|deg2rad|delete!|deleteat!|den|deserialize|det|detach|diag|diagind|diagm|diff|digamma|digits|digits!|dirname|disable_sigint|display|displayable|displaysize|div|divrem|done|dot|download|drop|dropzeros|dropzeros!|dump|e|eachindex|eachline|eachmatch|edit|eig|eigfact|eigfact!|eigmax|eigmin|eigs|eigvals|eigvals!|eigvecs|eltype|empty!|endof|endswith|enumerate|eof|eps|erf|erfc|erfcinv|erfcx|erfi|erfinv|error|esc|escape_string|eta|etree|eu|eulergamma|evalfile|exit|exp|exp10|exp2|expand|expanduser|expm|expm1|exponent|extrema|eye|factor|factorial|factorize|falses|fd|fdio|fetch|fft|fft!|fftshift|field_offset|fieldname|fieldnames|fieldoffset|fieldoffsets|filemode|filesize|fill|fill!|filt|filt!|filter|filter!|finalize|finalizer|find|findfirst|findin|findlast|findmax|findmax!|findmin|findmin!|findn|findnext|findnz|findprev|first|fld|fld1|fldmod|fldmod1|flipbits!|flipdim|flipsign|float|floor|flush|fma|foldl|foldr|foreach|frexp|full|fullname|functionloc|gamma|gc|gc_enable|gcd|gcdx|gensym|get|get!|get_bigfloat_precision|get_rounding|get_zero_subnormals|getaddrinfo|gethostname|getindex|getipaddr|getkey|getpid|getsockname|givens|golden|gperm|gradient|graphemes|hankelh1|hankelh1x|hankelh2|hankelh2x|hash|haskey|hcat|hessfact|hessfact!|hex|hex2bytes|hex2num|hist|hist!|hist2d|hist2d!|histrange|homedir|htol|hton|hvcat|hypot|idct|idct!|identity|ifelse|ifft|ifft!|ifftshift|ignorestatus|im|imag|in|include|include_dependency|include_string|ind2chr|ind2sub|indexin|indexpids|indices|indmax|indmin|info|init_worker|insert!|instances|interrupt|intersect|intersect!|inv|invdigamma|invmod|invperm|ipermute!|ipermutedims|irfft|is_apple|is_assigned_char|is_bsd|is_linux|is_unix|is_windows|isabspath|isalnum|isalpha|isapprox|isascii|isassigned|isbits|isblockdev|ischardev|iscntrl|isconst|isdiag|isdigit|isdir|isdirpath|isempty|isequal|iseven|isexecutable|isfifo|isfile|isfinite|isgeneric|isgraph|ishermitian|isimag|isimmutable|isinf|isinteger|isinteractive|isleaftype|isless|islink|islocked|islower|ismarked|ismatch|ismount|isnan|isnull|isnumber|isodd|isopen|ispath|isperm|isposdef|isposdef!|ispow2|isprime|isprint|ispunct|isqrt|isreadable|isreadonly|isready|isreal|issetgid|issetuid|issocket|issorted|isspace|issparse|issticky|issubnormal|issubset|issym|issymmetric|istaskdone|istaskstarted|istext|istextmime|istril|istriu|isupper|isvalid|iswritable|isxdigit|join|joinpath|keys|keytype|kill|kron|last|launch|lbeta|lcfirst|lcm|ldexp|ldltfact|ldltfact!|leading_ones|leading_zeros|length|less|levicivita|lexcmp|lexless|lfact|lgamma|linearindices|linreg|linspace|listen|listenany|localindexes|lock|log|log10|log1p|log2|logabsdet|logdet|logm|logspace|lowercase|lpad|lq|lqfact|lqfact!|lstat|lstrip|ltoh|lu|lufact|lufact!|lyap|macroexpand|manage|map|map!|mapfoldl|mapfoldr|mapreduce|mapreducedim|mapslices|mark|match|matchall|max|maxabs|maxabs!|maximum|maximum!|maxintfloat|mean|mean!|median|median!|merge|merge!|method_exists|methods|methodswith|middle|midpoints|mimewritable|min|minabs|minabs!|minimum|minimum!|minmax|mkdir|mkpath|mktemp|mktempdir|mod|mod1|mod2pi|modf|module_name|module_parent|mtime|muladd|mv|myid|names|nb_available|ndigits|ndims|next|nextfloat|nextind|nextpow|nextpow2|nextprod|nnz|nonzeros|norm|normalize|normalize!|normalize_string|normpath|notify|now|nprocs|nthperm|nthperm!|ntoh|ntuple|nullspace|num|num2hex|nworkers|nzrange|object_id|oct|oftype|one|ones|open|operm|ordschur|ordschur!|parent|parentindexes|parity|parse|parseip|partitions|peakflops|permutations|permute|permute!|permutedims|permutedims!|pi|pinv|pipeline|plan_bfft|plan_bfft!|plan_brfft|plan_dct|plan_dct!|plan_fft|plan_fft!|plan_idct|plan_idct!|plan_ifft|plan_ifft!|plan_irfft|plan_rfft|pmap|pointer|pointer_from_objref|pointer_to_array|pointer_to_string|poll_fd|poll_file|polygamma|pop!|popdisplay|position|powermod|precision|precompile|prepend!|prevfloat|prevind|prevpow|prevpow2|prevprod|primes|primesmask|print|print_escaped|print_joined|print_shortest|print_unescaped|print_with_color|println|process_exited|process_running|procs|prod|prod!|produce|promote|promote_rule|promote_shape|promote_type|push!|pushdisplay|put!|pwd|qr|qrfact|qrfact!|quadgk|quantile|quantile!|quit|rad2deg|rand|rand!|randcycle|randexp|randexp!|randjump|randn|randn!|randperm|randstring|randsubseq|randsubseq!|range|rank|rationalize|read|read!|readall|readandwrite|readavailable|readbytes|readbytes!|readchomp|readcsv|readdir|readdlm|readline|readlines|readlink|readstring|readuntil|real|realmax|realmin|realpath|recv|recvfrom|redirect_stderr|redirect_stdin|redirect_stdout|redisplay|reduce|reducedim|reenable_sigint|reim|reinterpret|reload|relpath|rem|rem1|remote|remotecall|remotecall_fetch|remotecall_wait|repeat|repeated|replace|repmat|repr|reprmime|reset|reshape|resize!|rest|rethrow|retry|reverse|reverse!|reverseind|rfft|rm|rmprocs|rol|rol!|ror|ror!|rot180|rotl90|rotr90|round|rounding|rowvals|rpad|rsearch|rsearchindex|rsplit|rstrip|run|scale|scale!|schedule|schur|schurfact|schurfact!|sdata|search|searchindex|searchsorted|searchsortedfirst|searchsortedlast|sec|secd|sech|seek|seekend|seekstart|select|select!|selectperm|selectperm!|send|serialize|set_bigfloat_precision|set_rounding|set_zero_subnormals|setdiff|setdiff!|setenv|setindex!|setprecision|setrounding|shift!|show|showall|showcompact|showcompact_lim|showerror|shuffle|shuffle!|sign|signbit|signed|signif|significand|similar|sin|sinc|sind|sinh|sinpi|size|sizehint!|sizeof|skip|skipchars|sleep|slice|slicedim|sort|sort!|sortcols|sortperm|sortperm!|sortrows|sparse|sparsevec|spawn|spdiagm|specialized_binary|specialized_bitwise_binary|specialized_bitwise_unary|specialized_unary|speye|splice!|split|splitdir|splitdrive|splitext|spones|sprand|sprandbool|sprandn|sprint|spzeros|sqrt|sqrtm|squeeze|srand|stacktrace|start|startswith|stat|std|stdm|step|stride|strides|string|stringmime|strip|strwidth|sub|sub2ind|subtypes|success|sum|sum!|sum_kbn|sumabs|sumabs!|sumabs2|sumabs2!|summary|super|supertype|svd|svdfact|svdfact!|svds|svdvals|svdvals!|sylvester|symbol|symdiff|symdiff!|symlink|symperm|systemerror|take|take!|takebuf_array|takebuf_string|tan|tand|tanh|task_local_storage|tempdir|tempname|tic|time|time_ns|timedwait|toc|toq|touch|trace|trailing_ones|trailing_zeros|trailingsize|transcode|transpose|transpose!|trigamma|tril|tril!|triu|triu!|trues|trunc|truncate|trylock|tryparse|typeintersect|typejoin|typemax|typemin|ucfirst|unescape_string|union|union!|unique|unlock|unmark|unsafe_copy!|unsafe_load|unsafe_pointer_to_objref|unsafe_read|unsafe_store!|unsafe_string|unsafe_trunc|unsafe_wrap|unsafe_write|unshift!|unsigned|uperm|uppercase|utf8|valtype|values|var|varm|vcat|vec|vecdot|vecnorm|versioninfo|view|wait|walkdir|warn|watch_file|which|whos|widemul|widen|with_bigfloat_precision|with_rounding|withenv|workers|workspace|write|writecsv|writedlm|xcorr|xdump|yield|yieldto|zero|zeros|zeta|zip|applicable|eval|fieldtype|getfield|invoke|is|isa|isdefined|issubtype|nfields|nothing|setfield!|throw|tuple|typeassert|typeof)(?!{{symb_id}})
+
+  # julia> join(string.(filter!(x -> isa(eval(x), Module), [names(Base); names(Core)])), "|")
+  base_modules: \b(?:BLAS|Base|Collections|Dates|Docs|FFTW|LAPACK|LibGit2|Libc|Libdl|LinAlg|Markdown|Meta|Mmap|Operators|Pkg|Profile|Serializer|SparseArrays|StackTraces|Sys|Test|Threads|Core|Main)\b
+
+  # Highlight exported functions from base modules
+  # julia> base_modules = filter!(x -> isa(eval(x), Module) && x != :Main , [names(Base); names(Core)])
+  # julia> modulefunctions(m) = join(filter!(x -> isascii(x[1]) && isalpha(x[1]) && islower(x[1]), string.(names(eval(m)))), "|")
+  # julia> regexify(m) = "$(string(m))\\.(?:$(modulefunctions(m)))"
+  # julia> rows = join(regexify.(base_modules), "|")
+  # julia> print("(<!\\.)(?:$rows)(?!{{symb_id}})")
+  base_module_func: (?<!\.)(?:BLAS\.(?:asum|blascopy!|dotc|dotu|gbmv|gbmv!|gemm|gemm!|gemv|gemv!|ger!|hemm|hemm!|hemv|hemv!|her!|her2k|her2k!|herk|herk!|iamax|nrm2|sbmv|sbmv!|scal|scal!|symm|symm!|symv|symv!|syr!|syr2k|syr2k!|syrk|syrk!|trmm|trmm!|trmv|trmv!|trsm|trsm!|trsv|trsv!)|Base\.(?:abs|abs2|abspath|accept|acos|acosd|acosh|acot|acotd|acoth|acsc|acscd|acsch|addprocs|airy|airyai|airyaiprime|airybi|airybiprime|airyprime|airyx|all|all!|allunique|angle|any|any!|append!|apropos|ascii|asec|asecd|asech|asin|asind|asinh|assert|asyncmap|atan|atan2|atand|atanh|atexit|atreplinit|backtrace|base|base64decode|base64encode|basename|besselh|besselhx|besseli|besselix|besselj|besselj0|besselj1|besseljx|besselk|besselkx|bessely|bessely0|bessely1|besselyx|beta|bfft|bfft!|big|bin|bind|binomial|bitbroadcast|bitpack|bitrand|bits|bitunpack|bkfact|bkfact!|blas_set_num_threads|blkdiag|brfft|broadcast|broadcast!|broadcast!_function|broadcast_function|broadcast_getindex|broadcast_setindex!|bswap|bytes2hex|bytestring|call|cat|catalan|catch_backtrace|catch_stacktrace|cbrt|cd|ceil|cell|cfunction|cglobal|charwidth|checkbounds|checkindex|chmod|chol|cholfact|cholfact!|chomp|chop|chown|chr2ind|circshift|cis|clamp|clamp!|cld|clear!|clipboard|close|cmp|code_llvm|code_lowered|code_native|code_typed|code_warntype|collect|colon|combinations|complex|cond|condskeel|conj|conj!|connect|consume|contains|conv|conv2|convert|copy|copy!|copysign|cor|cos|cosc|cosd|cosh|cospi|cot|cotd|coth|count|count_ones|count_zeros|countfrom|countlines|countnz|cov|cp|cross|csc|cscd|csch|ctime|ctranspose|ctranspose!|cummax|cummin|cumprod|cumprod!|cumsum|cumsum!|cumsum_kbn|current_module|current_task|cycle|dawson|dct|dct!|dec|deconv|deepcopy|default_worker_pool|deg2rad|delete!|deleteat!|den|deserialize|det|detach|diag|diagind|diagm|diff|digamma|digits|digits!|dirname|disable_sigint|display|displayable|displaysize|div|divrem|done|dot|download|drop|dropzeros|dropzeros!|dump|e|eachindex|eachline|eachmatch|edit|eig|eigfact|eigfact!|eigmax|eigmin|eigs|eigvals|eigvals!|eigvecs|eltype|empty!|endof|endswith|enumerate|eof|eps|erf|erfc|erfcinv|erfcx|erfi|erfinv|error|esc|escape_string|eta|etree|eu|eulergamma|evalfile|exit|exp|exp10|exp2|expand|expanduser|expm|expm1|exponent|extrema|eye|factor|factorial|factorize|falses|fd|fdio|fetch|fft|fft!|fftshift|field_offset|fieldname|fieldnames|fieldoffset|fieldoffsets|filemode|filesize|fill|fill!|filt|filt!|filter|filter!|finalize|finalizer|find|findfirst|findin|findlast|findmax|findmax!|findmin|findmin!|findn|findnext|findnz|findprev|first|fld|fld1|fldmod|fldmod1|flipbits!|flipdim|flipsign|float|floor|flush|fma|foldl|foldr|foreach|frexp|full|fullname|functionloc|gamma|gc|gc_enable|gcd|gcdx|gensym|get|get!|get_bigfloat_precision|get_rounding|get_zero_subnormals|getaddrinfo|gethostname|getindex|getipaddr|getkey|getpid|getsockname|givens|golden|gperm|gradient|graphemes|hankelh1|hankelh1x|hankelh2|hankelh2x|hash|haskey|hcat|hessfact|hessfact!|hex|hex2bytes|hex2num|hist|hist!|hist2d|hist2d!|histrange|homedir|htol|hton|hvcat|hypot|idct|idct!|identity|ifelse|ifft|ifft!|ifftshift|ignorestatus|im|imag|in|include|include_dependency|include_string|ind2chr|ind2sub|indexin|indexpids|indices|indmax|indmin|info|init_worker|insert!|instances|interrupt|intersect|intersect!|inv|invdigamma|invmod|invperm|ipermute!|ipermutedims|irfft|is_apple|is_assigned_char|is_bsd|is_linux|is_unix|is_windows|isabspath|isalnum|isalpha|isapprox|isascii|isassigned|isbits|isblockdev|ischardev|iscntrl|isconst|isdiag|isdigit|isdir|isdirpath|isempty|isequal|iseven|isexecutable|isfifo|isfile|isfinite|isgeneric|isgraph|ishermitian|isimag|isimmutable|isinf|isinteger|isinteractive|isleaftype|isless|islink|islocked|islower|ismarked|ismatch|ismount|isnan|isnull|isnumber|isodd|isopen|ispath|isperm|isposdef|isposdef!|ispow2|isprime|isprint|ispunct|isqrt|isreadable|isreadonly|isready|isreal|issetgid|issetuid|issocket|issorted|isspace|issparse|issticky|issubnormal|issubset|issym|issymmetric|istaskdone|istaskstarted|istext|istextmime|istril|istriu|isupper|isvalid|iswritable|isxdigit|join|joinpath|keys|keytype|kill|kron|last|launch|lbeta|lcfirst|lcm|ldexp|ldltfact|ldltfact!|leading_ones|leading_zeros|length|less|levicivita|lexcmp|lexless|lfact|lgamma|linearindices|linreg|linspace|listen|listenany|localindexes|lock|log|log10|log1p|log2|logabsdet|logdet|logm|logspace|lowercase|lpad|lq|lqfact|lqfact!|lstat|lstrip|ltoh|lu|lufact|lufact!|lyap|macroexpand|manage|map|map!|mapfoldl|mapfoldr|mapreduce|mapreducedim|mapslices|mark|match|matchall|max|maxabs|maxabs!|maximum|maximum!|maxintfloat|mean|mean!|median|median!|merge|merge!|method_exists|methods|methodswith|middle|midpoints|mimewritable|min|minabs|minabs!|minimum|minimum!|minmax|mkdir|mkpath|mktemp|mktempdir|mod|mod1|mod2pi|modf|module_name|module_parent|mtime|muladd|mv|myid|names|nb_available|ndigits|ndims|next|nextfloat|nextind|nextpow|nextpow2|nextprod|nnz|nonzeros|norm|normalize|normalize!|normalize_string|normpath|notify|now|nprocs|nthperm|nthperm!|ntoh|ntuple|nullspace|num|num2hex|nworkers|nzrange|object_id|oct|oftype|one|ones|open|operm|ordschur|ordschur!|parent|parentindexes|parity|parse|parseip|partitions|peakflops|permutations|permute|permute!|permutedims|permutedims!|pi|pinv|pipeline|plan_bfft|plan_bfft!|plan_brfft|plan_dct|plan_dct!|plan_fft|plan_fft!|plan_idct|plan_idct!|plan_ifft|plan_ifft!|plan_irfft|plan_rfft|pmap|pointer|pointer_from_objref|pointer_to_array|pointer_to_string|poll_fd|poll_file|polygamma|pop!|popdisplay|position|powermod|precision|precompile|prepend!|prevfloat|prevind|prevpow|prevpow2|prevprod|primes|primesmask|print|print_escaped|print_joined|print_shortest|print_unescaped|print_with_color|println|process_exited|process_running|procs|prod|prod!|produce|promote|promote_rule|promote_shape|promote_type|push!|pushdisplay|put!|pwd|qr|qrfact|qrfact!|quadgk|quantile|quantile!|quit|rad2deg|rand|rand!|randcycle|randexp|randexp!|randjump|randn|randn!|randperm|randstring|randsubseq|randsubseq!|range|rank|rationalize|read|read!|readall|readandwrite|readavailable|readbytes|readbytes!|readchomp|readcsv|readdir|readdlm|readline|readlines|readlink|readstring|readuntil|real|realmax|realmin|realpath|recv|recvfrom|redirect_stderr|redirect_stdin|redirect_stdout|redisplay|reduce|reducedim|reenable_sigint|reim|reinterpret|reload|relpath|rem|rem1|remote|remotecall|remotecall_fetch|remotecall_wait|repeat|repeated|replace|repmat|repr|reprmime|reset|reshape|resize!|rest|rethrow|retry|reverse|reverse!|reverseind|rfft|rm|rmprocs|rol|rol!|ror|ror!|rot180|rotl90|rotr90|round|rounding|rowvals|rpad|rsearch|rsearchindex|rsplit|rstrip|run|scale|scale!|schedule|schur|schurfact|schurfact!|sdata|search|searchindex|searchsorted|searchsortedfirst|searchsortedlast|sec|secd|sech|seek|seekend|seekstart|select|select!|selectperm|selectperm!|send|serialize|set_bigfloat_precision|set_rounding|set_zero_subnormals|setdiff|setdiff!|setenv|setindex!|setprecision|setrounding|shift!|show|showall|showcompact|showcompact_lim|showerror|shuffle|shuffle!|sign|signbit|signed|signif|significand|similar|sin|sinc|sind|sinh|sinpi|size|sizehint!|sizeof|skip|skipchars|sleep|slice|slicedim|sort|sort!|sortcols|sortperm|sortperm!|sortrows|sparse|sparsevec|spawn|spdiagm|specialized_binary|specialized_bitwise_binary|specialized_bitwise_unary|specialized_unary|speye|splice!|split|splitdir|splitdrive|splitext|spones|sprand|sprandbool|sprandn|sprint|spzeros|sqrt|sqrtm|squeeze|srand|stacktrace|start|startswith|stat|std|stdm|step|stride|strides|string|stringmime|strip|strwidth|sub|sub2ind|subtypes|success|sum|sum!|sum_kbn|sumabs|sumabs!|sumabs2|sumabs2!|summary|super|supertype|svd|svdfact|svdfact!|svds|svdvals|svdvals!|sylvester|symbol|symdiff|symdiff!|symlink|symperm|systemerror|take|take!|takebuf_array|takebuf_string|tan|tand|tanh|task_local_storage|tempdir|tempname|tic|time|time_ns|timedwait|toc|toq|touch|trace|trailing_ones|trailing_zeros|trailingsize|transcode|transpose|transpose!|trigamma|tril|tril!|triu|triu!|trues|trunc|truncate|trylock|tryparse|typeintersect|typejoin|typemax|typemin|ucfirst|unescape_string|union|union!|unique|unlock|unmark|unsafe_copy!|unsafe_load|unsafe_pointer_to_objref|unsafe_read|unsafe_store!|unsafe_string|unsafe_trunc|unsafe_wrap|unsafe_write|unshift!|unsigned|uperm|uppercase|utf8|valtype|values|var|varm|vcat|vec|vecdot|vecnorm|versioninfo|view|wait|walkdir|warn|watch_file|which|whos|widemul|widen|with_bigfloat_precision|with_rounding|withenv|workers|workspace|write|writecsv|writedlm|xcorr|xdump|yield|yieldto|zero|zeros|zeta|zip)|Collections\.(?:dequeue!|enqueue!|heapify|heapify!|heappop!|heappush!|isheap|peek)|Dates\.(?:adjust|datetime2julian|datetime2rata|datetime2unix|day|dayabbr|dayname|dayofmonth|dayofquarter|dayofweek|dayofweekofmonth|dayofyear|daysinmonth|daysinyear|daysofweekinmonth|firstdayofmonth|firstdayofquarter|firstdayofweek|firstdayofyear|hour|isleapyear|julian2datetime|lastdayofmonth|lastdayofquarter|lastdayofweek|lastdayofyear|millisecond|minute|month|monthabbr|monthday|monthname|now|quarterofyear|rata2datetime|recur|second|today|tofirst|tolast|tonext|toprev|unix2datetime|week|year|yearmonth|yearmonthday)|Docs\.(?:apropos|doc)|FFTW\.(?:dct|dct!|export_wisdom|fftwComplex|fftwNumber|fftwReal|flops|forget_wisdom|idct|idct!|import_system_wisdom|import_wisdom|plan_dct|plan_dct!|plan_idct|plan_idct!|plan_r2r|plan_r2r!|r2r|r2r!)|LAPACK\.(?:)|LibGit2\.(?:with)|Libc\.(?:calloc|errno|flush_cstdio|free|gethostname|getpid|malloc|realloc|strerror|strftime|strptime|systemsleep|time|transcode)|Libdl\.(?:dlclose|dlext|dllist|dlopen|dlopen_e|dlpath|dlsym|dlsym_e|find_library)|LinAlg\.(?:axpy!|bkfact|bkfact!|chol|cholfact|cholfact!|cond|condskeel|copy!|cross|ctranspose|det|diag|diagind|diagm|diff|dot|eig|eigfact|eigfact!|eigmax|eigmin|eigs|eigvals|eigvals!|eigvecs|expm|eye|factorize|givens|gradient|hessfact|hessfact!|isdiag|ishermitian|isposdef|isposdef!|issymmetric|istril|istriu|kron|ldltfact|ldltfact!|linreg|logabsdet|logdet|logm|lq|lqfact|lqfact!|lu|lufact|lufact!|lyap|norm|normalize|normalize!|nullspace|ordschur|ordschur!|peakflops|pinv|qr|qrfact|qrfact!|rank|scale!|schur|schurfact|schurfact!|sqrtm|svd|svdfact|svdfact!|svds|svdvals|svdvals!|sylvester|trace|transpose|tril|tril!|triu|triu!|vecdot|vecnorm)|Markdown\.(?:html|latex|license|readme)|Meta\.(?:isexpr|quot|show_sexpr)|Mmap\.(?:)|Operators\.(?:colon|ctranspose|getindex|hcat|hvcat|setindex!|transpose|vcat)|Pkg\.(?:add|available|build|checkout|clone|dir|free|init|installed|pin|resolve|rm|setprotocol!|status|test|update)|Profile\.(?:)|Serializer\.(?:deserialize|serialize)|SparseArrays\.(?:blkdiag|dense|droptol!|dropzeros|dropzeros!|issparse|nnz|nonzeros|nzrange|permute|rowvals|sparse|sparsevec|spdiagm|speye|spones|sprand|sprandn|spzeros|symperm)|StackTraces\.(?:catch_stacktrace|stacktrace)|Sys\.(?:cpu_info|cpu_name|cpu_summary|free_memory|loadavg|total_memory|uptime)|Test\.(?:detect_ambiguities)|Threads\.(?:atomic_add!|atomic_and!|atomic_cas!|atomic_fence|atomic_max!|atomic_min!|atomic_nand!|atomic_or!|atomic_sub!|atomic_xchg!|atomic_xor!|nthreads|threadid)|Core\.(?:applicable|eval|fieldtype|getfield|invoke|is|isa|isdefined|issubtype|nfields|nothing|setfield!|throw|tuple|typeassert|typeof))(?!{{symb_id}})
+
+  # Symbols part of the language syntax
+  symb_lang: (?:[(){}\[\],.;:'"`@#])
+
+  # General identifier symbol
+  symb_id: (?:[^\s{{symb_lang}}{{symb_op}}])
+
+  # Alternative to \b that works with unicode symbols
+  b: (?<=(?:^|\s|{{symb_lang}}|{{symb_op}}))
+
+  # Recursively match nested curly braces
+  # Must be wrapped in a matching group when used. It is best to do this explicitly when used (not here) to avoid confusion.
+  # This regex depends on atomic group and back reference recursion.
+  # Cannot match multi-line types, because sublime applies regexes line by line.
+  # TODO: Parse multi-line types separately with push/pop matching. Omg pls no! {nested_curly} is used in 10 places and push/pop would make the code very messy. Who uses multi-line types anyway?
+  nested_curly: '{(?>[^{}]+|\g<-1>)*}'
+  # Don't use the following ones for lookaheads! May lead to unwanted matches.
+  # These match unfinished nested braces, to highlight during typing.
+  nested_curly_sloppy: '(?:{(?>[^{}]+|\g<-1>)*}|\{[^\}\)\] ]*)'
+  nested_curly_and_round_sloppy: (?:(?>{(?>[^{}]+|\g<-1>)*}|\((?>[^()]+|\g<-1>)*\))|[\{\(][^\}\)\] ]*)
+
+  # Recursively match nested brackets (of any type) and strings
+  # Must be wrapped in a matching group when used. It is best to do this explicitly when used (not here) to avoid confusion.
+  # NOTE: Use of atomic groups speeds up parsing immensely.
+  string: '"(?>(?>\\"|[^"])*|\g<-1>)*"'
+  nested_brackets_and_strings: |-
+    (?x)
+    (?>
+       {(?>{{string}}|[^{}]+|\g<-1>)*}|
+      \((?>{{string}}|[^()]+|\g<-1>)*\)|
+      \[(?>{{string}}|[^\[\]]+|\g<-1>)*\]|
+      {{string}}
+    )
+
+  # Helpers for function declaration
+  type_comparison_regex: (\$?{{symb_id}}+({{nested_curly_and_round_sloppy}})?)\s*(<:|>:)\s*((?:(?!\.\.)(?:[$.]|{{symb_id}}))+({{nested_curly_and_round_sloppy}})?)
+  func_name_standard: |-
+    (?x)
+    (?!!)                     # Function name doesn't start with !
+    ([^\s{{symb_lang}}]+)     # Function name
+    ({{nested_curly}})?       # Match type annotation
+    (?=[\( ])
+  func_name_paren: |-
+    (?x)
+    \(                        # Function name is wrapped in parentheses
+    (?!!)                     # Function name doesn't start with !
+    (::)?                     # Function name can start with ::
+    ((?:                      # Rest of function name
+      ({{nested_curly}})|     # Match nested curly brackets
+      [^)]                    # or anything that doesn't close paren
+    )+)
+    \)
+    ({{nested_curly}})?       # Match type annotation
+    (?=\()
+  func_params: |-
+    (?x)
+    \(                        # Open function parameters
+    # We are lazy here and don't parse the exact form of a parameter list
+    # with types, default values, splats etc. It is not needed.
+    (
+      ({{nested_brackets_and_strings}})| # Match nested brackets, can occur in parameter default value etc.
+      [^(){}\[\]"]            # or anything that doesn't close the argument list
+    )*
+    \)                        # Close function parameters
+    (                         # Allow where keyword
+      \s*where\s+
+      (
+        {{type_comparison_regex}}|
+        {{nested_curly}}|
+        {{symb_id}}+
+      )
+    )*
+    \s*=(?!=)                 # Followed by exactly one equal sign
+
+contexts:
+  main:
+    - include: declarations
+    - include: expressions
+
+  expressions:
+    - include: comments
+    - include: symbols
+    - include: type-annotation
+    - include: type-comparison
+    - include: literals
+    - include: operators
+    - include: strings
+    - include: keywords
+    - include: macros
+    - include: support-functions
+    - include: function-call
+    - include: anonymous-function
+    - include: variable
+    - include: nested_parens
+    - include: nested_squarebrackets
+
+  declarations:
+    - include: decl-func
+    - include: decl-func-assignment-form
+    - include: decl-type
+    - include: decl-macro
+    - include: decl-typealias
+
+  comments:
+    - match: '#='
+      push: comment-block
+    - match: '#.*'
+      scope: comment.line.number-sign.julia
+
+  comment-block:
+    - meta_scope: comment.block.number-sign-equals.julia
+    - match: '#='
+      push: comment-block
+    - match: '=#'
+      pop: true
+
+  keywords:
+    - match: \b(begin|end|function|type|macro|quote|let|local|global|const|abstract|typealias|bitstype|immutable|module|baremodule|using|import|export|importall|in)\b
+      scope: keyword.other.julia
+    - match: \b(if|else|elseif|for|while|do|try|catch|finally|return|break|continue)\b
+      scope: keyword.control.julia
+
+  operators:
+    # Bang is not only an operator symbol, it can also be part of a function name, thus it is treated separately.
+    # Single quote is not only an operator symbol, it can also start a string. It is an operator if it is preceded by an identifier, dot, single-quote, right round bracket or right square bracket
+    - match: (\.?)({{long_op}})
+      captures:
+        1: keyword.operator.broadcast.julia
+        2: keyword.operator.julia
+    - match: (\.?)(=)
+      captures:
+        1: keyword.operator.broadcast.julia
+        2: keyword.operator.assignment.julia
+    - match: (\.)({{symb_op}}|')
+      captures:
+        1: keyword.operator.broadcast.julia
+        2: keyword.operator.julia
+    - match: |-
+        (?x)
+        (
+          {{symb_op}}|
+          !|
+          (?<=
+            (
+              {{symb_id}}|
+              [.')\]]
+            )
+          )
+          '
+        )
+      scope: keyword.operator.julia
+
+  support-functions:
+    - match: '(?={{base_module_func}}\.?({{nested_curly}})?\()'
+      push:
+        - match: ({{base_modules}})\.
+          captures:
+            1: support.module.julia
+        - match: (?<=\.)({{symb_id}}+)
+          scope: variable.function.julia support.function.julia meta.function-call.julia
+          push: function-call-helper
+        - match: ''
+          pop: true
+    - match: '(?={{base_module_func}})'
+      push:
+        - match: ({{symb_id}}+)\.
+          captures:
+            1: support.module.julia
+        - match: (?<=\.)({{symb_id}}+)
+          scope: variable.function.julia support.function.julia
+        - match: ''
+          pop: true
+
+  function-call:
+    - match: '(?<!\.)(?={{symb_id}}+\.?({{nested_curly}})?\()'
+      push:
+        - meta_content_scope: meta.function-call.julia
+        # Built-in function
+        - match: '{{base_funcs}}'
+          scope: variable.function.julia support.function.julia
+        - include: function-call-helper
+        - match: ''
+          pop: true
+    - match: '(?=({{symb_id}}+)\.?({{nested_curly}})?\()'
+      push: function-call-helper
+
+  function-call-helper:
+    - meta_content_scope: meta.function-call.julia
+    # Function
+    - match: '{{symb_id}}+'
+      scope: variable.function.julia
+    # Type
+    - match: ({{nested_curly}})
+      scope: support.type.julia
+    # Broadcast
+    - match: '\.'
+      scope: keyword.operator.broadcast.julia
+    # Begin arguments
+    - match: \(
+      set:
+        - meta_content_scope: meta.function-call.arguments.julia
+        - match: '({{symb_id}}+)\s*(=)'
+          captures:
+            1: variable.parameter.julia
+            2: keyword.operator.assignment.julia
+        - include: expressions
+        # End arguments and function call
+        - match: \)
+          scope: meta.function-call.julia
+          pop: true
+
+  literals:
+    - match: |-
+        (?x)
+        (?: # Dashes betwen numeric symbols (11 = 1_1) are allowed everywhere.
+          {{b}}0b[0-1](?:_?[0-1])*|             # binary
+          {{b}}0o[0-7](?:_?[0-7])*|             # octal
+          {{b}}0x[\da-fA-F](?:_?[\da-fA-F])*|   # hex
+          {{b}}(?:
+            \.\d(?:_?\d)*|                      # .11, .11
+            \d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?  # 11.11, 11., 11
+          )
+          (?:e[-+]?\d(?:_?\d)*)?                # Any of the above followed by e+123 or similar, for scientific notation.
+        )
+      scope: constant.numeric.julia
+    - match: \b(true|false|nothing|NaN|Inf)\b
+      scope: constant.language.julia
+
+  type-annotation:
+    # Dollar is ok because types can be interpolated.
+    # Dot is ok because types can be picked from modules,
+    # but no more than one dot, because splat can follow type.
+    - match: (::)\s*((?:(?!\.\.)(?:[$.]|{{symb_id}}))*({{nested_curly_and_round_sloppy}})?)\s*(where)\s+
+      captures:
+        1: keyword.operator.julia
+        2: support.type.julia
+        4: keyword.other.julia
+      push: where-type
+    - match: (::|<:|>:)\s*((?:(?!\.\.)(?:[$.]|{{symb_id}}))*({{nested_curly_and_round_sloppy}})?)
+      captures:
+        1: keyword.operator.julia
+        2: support.type.julia
+
+  type-comparison:
+    - match: '{{type_comparison_regex}}'
+      captures:
+        1: support.type.julia
+        3: keyword.operator.julia
+        4: support.type.julia
+
+  where-type:
+    - match: (\{){{type_comparison_regex}}(\})
+      captures:
+        1: support.type.julia
+        2: support.type.julia
+        4: keyword.operator.julia
+        5: support.type.julia
+        7: support.type.julia
+    - match: '{{type_comparison_regex}}'
+      captures:
+        1: support.type.julia
+        3: keyword.operator.julia
+        4: support.type.julia
+    - match: '({{nested_curly_sloppy}})'
+      scope: support.type.julia
+    - match: '{{symb_id}}+'
+      scope: support.type.julia
+    - match: \s*(where)\s+
+      captures:
+        1: keyword.other.julia
+      push: where-type
+    - match: ''
+      pop: true
+
+  decl-func:
+    - match: '\b(?<!:)(function)\s+(?!@)'
+      captures:
+        1: keyword.other.julia
+      push:
+        - meta_scope: meta.function.julia
+        - include: func-name-paren
+        - include: func-name-standard
+        # Anonymous function
+        - match: \(
+          set: function-parameters
+        # Function name on the form "Module.func"
+        - match: '([^.{(]+)(\.)'
+          captures:
+            1: variable.other.julia
+            2: keyword.operator.julia
+
+  anonymous-function:
+    - match: '(?=({{nested_brackets_and_strings}})\s*->)'
+      set: function-parameters
+    - match: '({{symb_id}}+)(::)?({{symb_id}}+)?({{nested_curly}})?\s*(->)'
+      captures:
+        1: variable.parameter
+        2: keyword.operator
+        3: support.type
+        4: support.type
+        5: keyword.operator
+    - match: '({{symb_id}}+)\s*(->)'
+      captures:
+        1: variable.parameter
+        2: keyword.operator
+
+  # Do lookaheads to distinguish function calls from function definitions on assignment form
+  decl-func-assignment-form:
+    - match: |-
+        (?x)
+        (?=
+          {{func_name_paren}}
+          {{func_params}}
+        )
+      push: func-name-paren
+    - match: |-
+        (?x)
+        (?=
+          {{func_name_standard}}
+          {{func_params}}
+        )
+      push: func-name-standard
+    - match: |-
+        (?x)
+        (?=
+          (?!!)
+          ([^\s{{symb_lang}}]+\.)+
+          {{func_name_standard}}
+          {{func_params}}
+        )
+      push:
+        - match: '({{base_modules}})\.(?=[^\s{{symb_lang}}])'
+          captures:
+            1: support.module.julia
+          push: func-name-standard
+          pop: true
+        - match: '(([^\s{{symb_lang}}]+\.)+)(?=[^\s{{symb_lang}}])'
+          captures:
+            1: variable.other.julia
+          push: func-name-standard
+          pop: true
+
+  func-name-standard:
+    - match: '{{func_name_standard}}'
+      captures:
+        1: entity.name.function.julia
+        2: support.type.julia
+      set: function-parameters
+
+  func-name-paren:
+    - match: '{{func_name_paren}}'
+      captures:
+        1: keyword.operator.julia
+        2: entity.name.function.julia
+        4: support.type.julia
+      set: function-parameters
+
+  function-parameters:
+    - meta_content_scope: meta.function.parameters.julia
+    - match: end
+      scope: keyword.other
+      pop: true
+    - match: \)\s*(where)\s+
+      captures:
+        1: keyword.other
+      set: where-type
+    - match: \)
+      pop: true
+    - include: comments
+    - match: '='
+      scope: keyword.operator.assignment.julia
+      set:
+        - meta_scope: meta.function.parameters.default-value.julia
+        - match: '(?=[,;)])'
+          set: function-parameters
+        - include: expressions
+    - include: type-annotation
+    - match: \.\.\. # Splat after type
+      scope: keyword.operator.julia
+    - match: ({{symb_id}}+)(\.\.\.)?
+      captures:
+        1: variable.parameter.julia
+        2: keyword.operator.julia
+
+  decl-macro:
+    - match: '\b(macro)\s+([^(]+)\('
+      captures:
+        1: keyword.other.julia
+        2: entity.name.macro.julia
+      set: function-parameters
+
+  decl-type:
+    # Dollar is ok because type names can be interpolated.
+    - match: \b(?:(mutable)\s+(struct)|(abstract)\s+(type)|(primitive)\s+(type))\s+((?:\$|{{symb_id}})+)({{nested_curly}})?
+      scope: meta.type.julia
+      captures: # Make this less repetitive?
+        1: keyword.other.julia
+        2: keyword.other.julia
+        3: keyword.other.julia
+        4: keyword.other.julia
+        5: keyword.other.julia
+        6: keyword.other.julia
+        7: entity.name.type.julia
+        8: support.type.julia
+    - match: \b(type|struct|immutable|abstract)\s+((?:\$|{{symb_id}})+)({{nested_curly}})?
+      scope: meta.type.julia
+      captures:
+        1: keyword.other.julia
+        2: entity.name.type.julia
+        3: support.type.julia
+    - match: \b(bitstype)\s+(\d+)\s+({{symb_id}}+({{nested_curly}})?)
+      captures:
+        1: keyword.other.julia
+        2: constant.numeric.julia
+        3: entity.name.type.julia
+
+  decl-typealias: # DEPRECATED 0.6
+    - match: \b(typealias)\s+({{symb_id}}+)({{nested_curly}})?\s+({{symb_id}}+({{nested_curly}})?)?
+      captures:
+        1: keyword.other.julia
+        2: entity.name.type.julia
+        3: entity.name.type.julia # Duplication because {{nested_curly}} must be wrapped in a matching group
+        4: support.type.julia
+
+  symbols:
+    # This is slightly more involved than what one might first expect
+    # because, for example, in `:aa` the symbol is `aa` but in `:+a` only `+` is the symbol.
+    # Also take some extra steps to not mess up ternary a?b:c syntax.
+    - match: |-
+        (?x)
+        (?<! {{symb_id}}: )   # Not preceded by `a:`
+        (?<! {{symb_id}}\s: ) # or `a :` (How to match multiple spaces in lookbehind?)
+        (?<! [<)}\].'"]: )    # or other symbol-blocking chars.
+        (?<=:)                # Preceeded by colon.
+        (                     # The actual symbol can be a
+          (\.?{{long_op}})|   # (dotted) multi-character-operator
+          (\.?{{symb_op}})|   # (dotted) operator
+          @?{{symb_id}}*      # variable (or macro) name
+        )
+      scope: constant.other.symbol.julia
+
+  macros:
+    - match: '@{{symb_id}}+\b'
+      # Julians want their macros to light up as functions by default
+      # The scope `variable.macro` is applied last to give it precedence
+      # so that user can override the color in the color theme.
+      scope: support.function.julia variable.macro.julia
+
+  variable:
+    - match: '({{symb_id}}+({{nested_curly_sloppy}})?)\s*(where)\s+'
+      captures:
+        1: support.type.julia
+        3: keyword.other.julia
+      push: where-type
+    - match: '{{symb_id}}+({{nested_curly_sloppy}})'
+      scope: support.type.julia
+    - match: '{{base_types}}'
+      scope: support.type.julia
+    - match: '{{base_funcs}}'
+      scope: variable.function.julia support.function.julia
+    - match: '(?<!\.){{base_modules}}'
+      scope: support.module.julia
+    - match: '{{symb_id}}+'
+      scope: variable.other.julia
+
+  strings:
+    # Regex string, tripple-quoted. Has special escaping and no string interpolation.
+    - match: '\br"""'
+      push:
+      - meta_scope: string.quoted.other.julia
+      - match: (\\"|\\\\)
+        scope: constant.character.escape.julia
+      - match: '"""'
+        pop: true
+    # Regex string. Has special escaping and no string interpolation.
+    - match: '\br"'
+      push:
+      - meta_scope: string.quoted.other.julia
+      - match: (\\"|\\\\)
+        scope: constant.character.escape.julia
+      - match: '"'
+        pop: true
+    # Triple double-quoted string
+    - match: '"""'
+      push: string-triple-content
+    # Double-quoted
+    - match: '"'
+      push: string-standard-content
+    # Prefixed double-quoted
+    - match: '{{symb_id}}+"'
+      push:
+      - meta_scope: string.quoted.other.julia
+      - include: string-escape
+      - match: '"'
+        pop: true
+    # Single-quoted string
+    - match: "'"
+      push:
+      - meta_scope: string.quoted.single.julia
+      - include: string-escape
+      - match: "'"
+        pop: true
+    # Cmd string
+    - match: '`'
+      push: string-cmd-content
+
+  string-escape:
+    - match: \\(\\|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8}|.)
+      scope: constant.character.escape.julia
+
+  string-standard-content:
+    - meta_scope: string.quoted.double.julia
+    - match: '"'
+      pop: true
+    - include: string-escape
+    - match: \$
+      scope: keyword.operator.julia
+      set: string-standard-interpolation
+
+  string-standard-interpolation:
+    - match: (?<=\))
+      set: string-standard-content
+    - include: nested_parens
+    - match: '{{symb_id}}+'
+      scope: variable.other.julia
+      set:
+        - match: ''
+          set: string-standard-content
+
+  string-triple-content:
+    - meta_scope: string.quoted.double.julia
+    - match: '"""'
+      pop: true
+    - include: string-escape
+    - match: \$
+      scope: keyword.operator.julia
+      set: string-triple-interpolation
+
+  string-triple-interpolation:
+    - match: (?<=\))
+      set: string-triple-content
+    - include: nested_parens
+    - match: '{{symb_id}}+'
+      scope: variable.other.julia
+      set:
+        - match: ''
+          set: string-triple-content
+
+  string-cmd-content:
+    - meta_scope: string.quoted.cmd.julia
+    - match: '`'
+      pop: true
+    - include: string-escape
+    - match: \$
+      scope: keyword.operator.julia
+      set: string-cmd-interpolation
+
+  string-cmd-interpolation:
+    - match: (?<=\))
+      set: string-cmd-content
+    - include: nested_parens
+    - match: '{{symb_id}}+'
+      scope: variable.other.julia
+      set:
+        - match: ''
+          set: string-cmd-content
+
+  nested_parens:
+    - match: \(
+      push:
+        - match: \)
+          pop: true
+        - include: declarations
+        - include: expressions
+
+  nested_squarebrackets:
+    - match: \[
+      push:
+        - match: \]
+          pop: true
+        - include: expressions

--- a/syntax_test_julia.jl
+++ b/syntax_test_julia.jl
@@ -981,6 +981,29 @@
 
   a=b
 #  ^ keyword.operator.assignment
+  a >= b
+#   ^ keyword.operator.julia
+  a <= b
+#   ^ keyword.operator.julia
+  x -> 2 + x
+#   ^ keyword.operator
+  a => b
+#   ^ keyword.operator.julia
+  x .-= 3
+#   ^ keyword.operator.broadcast.julia
+#    ^ keyword.operator.julia
+  a == b
+#   ^ keyword.operator.julia
+  a != b
+#   ^ keyword.operator.julia
+  a === b
+#   ^ keyword.operator.julia
+#    ^ keyword.operator.julia
+#     ^ keyword.operator.julia
+  a !== b
+#   ^ keyword.operator.julia
+#    ^ keyword.operator.julia
+#     ^ keyword.operator.julia
 
 # (issue 6, 8, 10)
   2.⊗a


### PR DESCRIPTION
When using a font with ligatures in Sublime Text 3 (e.g. Fira Code), the ligatures for multi-character operators, e.g. `>=` and `==` don't display correctly. This is because these are not treated as one token by the syntax parser. They were instead were being treated as an assignment. With these changes, these operators display correctly as ligatures. It might make sense for them to belong to a new category e.g. `keyword.operator.comparison`, but I'll leave that decision up to you. 