### PR TITLE
Add ≤ and ≥ autocomplete

### DIFF
--- a/julia_unicode/latex_symbols.py
+++ b/julia_unicode/latex_symbols.py
@@ -549,6 +549,8 @@ latex_symbols = [
   ("\\sansE", u"𝖤"),
   ("\\rightdotarrow", u"⤑"),
   ("\\leqslant", u"⩽"),
+  ("\\leq", u"≤"),
+  ("\\geq", u"≥"),
   ("\\questeq", u"≟"),
   ("\\trnr", u"ɹ"),
   ("\\wp", u"℘"),


### PR DESCRIPTION
Add `\leq` and `\geq` (`≤` and `≥`) in the autocomplete.

I don't know if there is a precise order for the symbols in `julia_unicode/latex_symbols.py`. I put the two definitions right after `\leqslant`.

This PR addresses #83.