### PR TITLE
Remove @ and ! from default word separators

### DIFF
--- a/Julia.sublime-settings
+++ b/Julia.sublime-settings
@@ -1,4 +1,6 @@
 {
     // inhibit auto completion menu for \:, otherwise emoji would not been shown
-    "auto_complete_selector": "meta.tag - punctuation.definition.tag.begin, source - meta.disable-completion - comment - string.quoted.double.block - string.quoted.single.block - string.unquoted.heredoc"
+    "auto_complete_selector": "meta.tag - punctuation.definition.tag.begin, source - meta.disable-completion - comment - string.quoted.double.block - string.quoted.single.block - string.unquoted.heredoc",
+    // @ and ! are frequently used in identifiers and therefore are excluded from the default word separators
+    "word_separators": "./\\()\"'-:,.;<>~#$%^&*|+=[]{}`~?"
 }


### PR DESCRIPTION
I think it would be convenient to exclude `@` and `!` from the default word separators, because those symbols are frequently used in identifiers (macros & in-place operating functions). This applies for example when double-clicking on an identifier or selecting the word from an empty selection with <kbd>Ctrl</kbd>+<kbd>D</kbd>.