### PR TITLE
Snippet indents using tabs

### DIFF
--- a/Snippets/begin.sublime-snippet
+++ b/Snippets/begin.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 begin
-    $0
+	$0
 end
 ]]></content>
   <tabTrigger>begin</tabTrigger>


### PR DESCRIPTION
This change replaces space indentation with tabs in each `.sublime-snippet`.
From Sublime Text snippet [documentation](https://docs.sublimetext.io/guide/extensibility/snippets.html#snippets-file-format):
> When writing a snippet that contains indentation, always use tabs. When the snippet is inserted, the tabs will be transformed into spaces if the option `translateTabsToSpaces` is true.