### PR TITLE
Snippets to use tabs instead of spaces

### DIFF
--- a/Snippets/begin.sublime-snippet
+++ b/Snippets/begin.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 begin
-    $0
+	$0
 end
 ]]></content>
   <tabTrigger>begin</tabTrigger>

--- a/Snippets/for.sublime-snippet
+++ b/Snippets/for.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 for $1
-    $0
+	$0
 end
 ]]></content>
   <tabTrigger>for</tabTrigger>

--- a/Snippets/function.sublime-snippet
+++ b/Snippets/function.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 function $1($2)
-    $0
+	$0
 end
 ]]></content>
   <tabTrigger>fun</tabTrigger>

--- a/Snippets/if.sublime-snippet
+++ b/Snippets/if.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 if $1
-    $0
+	$0
 end
 ]]></content>
   <tabTrigger>if</tabTrigger>

--- a/Snippets/struct.sublime-snippet
+++ b/Snippets/struct.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 struct $1
-    $0
+	$0
 end
 ]]></content>
   <tabTrigger>struct</tabTrigger>

--- a/Snippets/while.sublime-snippet
+++ b/Snippets/while.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 while $1
-    $0
+	$0
 end
 ]]></content>
   <tabTrigger>while</tabTrigger>


### PR DESCRIPTION
This change replaces space indentation with tabs in each `Snippets/*.sublime_snippet`.
As per Sublime Text [documentation](https://docs.sublimetext.io/guide/extensibility/snippets.html#snippets-file-format):
 > When writing a snippet that contains indentation, **always use tabs**. When the snippet is inserted, the tabs will be transformed into spaces if the option `translate_tabs_to_spaces` is `true`.